### PR TITLE
docs: clarify community and contribution paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,11 @@ Contributions come in three forms: enhancement requests, recipes, and examples.
 Each has a defined path. Follow it and your contribution ships faster.
 
 If you are still shaping an early connector or feature idea, start in
-[Community Discussions](community/README.md) so the team and other users can
-ask questions and upvote the direction. Use this guide when you have a concrete
-request, bug report, recipe, or tested example ready to track.
+[Community Discussions](https://github.com/CorpusIQ/corpusiq-docs/discussions)
+so the team and other users can ask questions and upvote the direction. Use the
+[Community guide](community/README.md) to pick the right category. Use this guide
+when you have a concrete request, bug report, recipe, or tested example ready to
+track.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,11 @@ Reference: github.com/CorpusIQ/corpusiq-docs
 Contributions come in three forms: enhancement requests, recipes, and examples.
 Each has a defined path. Follow it and your contribution ships faster.
 
+If you are still shaping an early connector or feature idea, start in
+[Community Discussions](community/README.md) so the team and other users can
+ask questions and upvote the direction. Use this guide when you have a concrete
+request, bug report, recipe, or tested example ready to track.
+
 ---
 
 ## Enhancement Requests
@@ -82,3 +87,6 @@ Use the issue tracker.
 
 Use GitHub Discussions, not issues:
 https://github.com/CorpusIQ/corpusiq-docs/discussions
+
+The [Community guide](community/README.md) explains which Discussion category to
+use for Q&A, early ideas, announcements, and show-and-tell posts.

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Common issues and fixes for CorpusIQ users.
 
 | Page | Content |
 |------|---------|
-| [Contributing](/CONTRIBUTING.md) | How to contribute to the docs |
-| [Community](/community/) | Community guidelines and resources |
+| [Contributing](/CONTRIBUTING.md) | Specific enhancement requests, recipes, examples, and bug reports |
+| [Community](/community/) | Questions, early ideas, upvotes, and discussion paths |
 | [Progress](/PROGRESS.md) | Documentation completion tracker |
 | [Changelog](/changelog/) | What changed and when |
 | [Roadmap](/roadmap/) | Upcoming features and docs |
@@ -148,6 +148,7 @@ Common issues and fixes for CorpusIQ users.
 | Can my autonomous agent use this? | [Hermes Community Hub →](/hermes/) |
 | Something's broken. Help? | [Troubleshooting →](/troubleshooting/) |
 | I want to contribute. | [Contributing →](/CONTRIBUTING.md) |
+| I have a connector idea. | [Community →](/community/) |
 
 ---
 

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -106,7 +106,13 @@ Your agent now has access to 36 business data sources. Use it for:
 
 ## What's Next?
 
-- Browse the [prompts library](../prompts/) for 60+ copy-paste queries
-- Check [connector documentation](../connectors/) for specific setup guides
-- Review [troubleshooting](../troubleshooting/) if you hit issues
-- Join the [community](../community/) to request features or connectors
+- Browse the [prompts library](/prompts/) for 60+ copy-paste queries
+- Check [connector documentation](/connectors/) for specific setup guides
+- Review [troubleshooting](/troubleshooting/) if you hit issues
+- Join the [community](/community/) for questions, early connector ideas, and
+  upvotes
+- Open a [Connector Enhancement Request](https://github.com/CorpusIQ/corpusiq-docs/issues/new/choose)
+  when you have a specific connector need with a clear use case, workaround, and
+  business impact
+- Read [Contributing](/CONTRIBUTING.md) before submitting recipes, examples,
+  bug reports, or concrete enhancement requests


### PR DESCRIPTION
## Summary

- clarify the root docs navigation difference between Community and Contributing
- point early connector/feature ideas to Community Discussions before they become tracked requests
- update onboarding next steps so users can distinguish Q&A, early ideas, specific connector enhancement requests, and contribution paths

## Validation

- git diff --check