### PR TITLE
docs(skills): add Engineering section — 7 platform-construction skills

### DIFF
--- a/hermes/index.md
+++ b/hermes/index.md
@@ -47,7 +47,7 @@ How agents are structured, coordinated, and improved.
 
 | Page | Content |
 |------|---------|
-| [Catalog](/hermes/skills/catalog/) | Every skill: 73 native + 69 marketplace, categorized |
+| [Catalog](/hermes/skills/catalog/) | Every skill: 80 native + 217 marketplace, categorized |
 | [Marketplace](/hermes/skills/marketplace/) | 85 curated skills from skills.sh with install counts |
 | [Marketing](/hermes/skills/marketing/) | 45 SEO, CRO, ads, content, growth skills |
 | [Development](/hermes/skills/development/) | GitHub, code review, issues, CI/CD skills |

--- a/hermes/skills/catalog/index.md
+++ b/hermes/skills/catalog/index.md
@@ -9,11 +9,11 @@ Complete index of all skills available to CorpusIQ Hermes agents. Updated as ski
 
 Skills are reusable agent capabilities — step-by-step workflows with tools, triggers, and verification. Not static prompts. Not text files. Executable runbooks that agents read and follow.
 
-**290 total**: 73 native + 217 marketplace.
+**297 total**: 80 native + 217 marketplace.
 
 ---
 
-## Native CorpusIQ Skills (73)
+## Native CorpusIQ Skills (80)
 
 Built and maintained for the CorpusIQ Hermes deployment. Loaded automatically when the agent profile matches.
 
@@ -165,6 +165,18 @@ Built and maintained for the CorpusIQ Hermes deployment. Loaded automatically wh
 | Skill | What It Does |
 |-------|-------------|
 | `corpusiq-gbrain-operations` | Operate GBrain — Garry Tan's agent brain layer |
+
+### Engineering (7) — Platform Construction
+
+| Skill | What It Does |
+|-------|-------------|
+| [`consultant-connector-audit`](/hermes/skills/engineering/consultant-connector-audit/) | 13-section audit pass before shipping any non-core-authored connector. Catches Mailchimp-style silent-failure clusters before they ship to customers |
+| [`mcp-architecture`](/hermes/skills/engineering/mcp-architecture/) | Operating-scale field guide for a 50k+ LOC MCP server: file map, per-connector triplet, dual-render-path trap, bulk-regex migration |
+| [`metric-spec-registry`](/hermes/skills/engineering/metric-spec-registry/) | Canonical-layer metric subsystem — declared KPI definitions, live resolution, drift detection between sources, never cached |
+| [`api-development`](/hermes/skills/engineering/api-development/) | Cloud Run + FastAPI patterns: test-fixture traps, self-destructing admin migrations, JWT JWKS contract with consumers |
+| [`frontend-development`](/hermes/skills/engineering/frontend-development/) | Next.js + Vercel patterns for marketing + dashboard in one repo: canonical-constant rule, deploy verification, cross-repo boundary |
+| [`scheduled-jobs`](/hermes/skills/engineering/scheduled-jobs/) | Hermes cron operating manual: server-local time, profile vs default split, no-agent watchdog pattern, in-prompt-curl trap |
+| [`honcho-memory-usage`](/hermes/skills/engineering/honcho-memory-usage/) | Server-side semantic memory via Honcho MCP — when it complements MEMORY.md/USER.md, when to read vs write, cost discipline |
 
 ---
 
@@ -417,7 +429,8 @@ Highlights: Firecrawl web scraping (6 skills, 70K+ installs), MCP builder (71.6K
 | Job Applications | 2 |
 | Core Knowledge | 3 |
 | GBrain | 1 |
-| **Native subtotal** | **73** |
+| Engineering | 7 |
+| **Native subtotal** | **80** |
 | Marketing & Growth (marketplace) | 45 |
 | Development (marketplace) | 10 |
 | Creative & Media (marketplace) | 3 |

--- a/hermes/skills/engineering/api-development/index.md
+++ b/hermes/skills/engineering/api-development/index.md
@@ -1,0 +1,105 @@
+---
+title: api-development
+description: Pattern for operating a FastAPI backend on Cloud Run as the single token issuer to a multi-service stack. Test fixture traps, self-destructing admin migrations for live DB changes, the JWT JWKS contract with consumers, and how to verify a deploy actually went out.
+---
+
+# API Development (Cloud Run + FastAPI)
+
+When your stack has multiple services (MCP servers, frontend, workers) and one of them is the **token issuer** — the FastAPI backend that mints JWTs everything else verifies — the discipline for that service is meaningfully different from the discipline for the consumers.
+
+## The single-token-issuer rule
+
+If you have one auth-issuing API and multiple JWT-consuming services:
+
+- The API publishes `/.well-known/jwks.json` (or equivalent)
+- Every consumer fetches the JWKS and verifies tokens locally — no auth round-trip per request
+- The API is the ONLY service that knows how to mint tokens; consumers are read-only on auth
+- Schema changes to the JWT payload require coordinated deploys across consumers (the API issues new-shape tokens, consumers must handle both shapes during the transition)
+
+This is the boring, correct pattern. The mistake to avoid: scattering token-validation logic so each service does its own (eventually two services drift, and a token works on one but not the other).
+
+## FastAPI test-fixture traps (regression-test recipe)
+
+When you're writing an after-the-fact regression test for a security or auth fix, the test fixture is usually the hardest part. The following five traps each cost an hour on the first encounter:
+
+### 1. JSONB compile hook ordering (SQLite test DB)
+
+If your prod DB is Postgres but your test DB is SQLite, you'll have JSONB columns SQLite doesn't natively support. Most projects solve this with a compile hook (`@compiles(JSONB, "sqlite")`) that maps JSONB to TEXT. **The hook MUST be imported before any model that uses JSONB.** Otherwise the model's `metadata.create_all()` fires before the hook lands and the column gets created with the wrong type.
+
+Recipe: import the hook module at the top of your test conftest.py, BEFORE any model imports.
+
+### 2. UUID type mismatch between raw-SQL inserts and SQLAlchemy column adapters
+
+SQLite stores UUIDs as either TEXT or BLOB depending on the column adapter. If you do a raw SQL `INSERT` for test fixtures and the column was declared as UUID(as_uuid=True), the adapter expects a UUID object — not a string. The raw insert puts a string in; the next ORM read tries to deserialize the string as a UUID and crashes.
+
+Recipe: insert via SQLModel/SQLAlchemy ORM in fixtures, not raw SQL. Or, use `str(uuid.uuid4())` consistently and skip the as_uuid=True.
+
+### 3. `metadata.create_all()` pulling in Postgres-only tables
+
+If your models include something like `audit_logs` declared in a Postgres-only module (because audit is Postgres-only and your test setup imports models broadly), `create_all()` on SQLite will choke on Postgres-specific types like `JSONB[]` or `pg_trgm` indexes.
+
+Recipe: narrow `metadata.create_all()` to the exact tables your test needs. Skip the `auth.users` FK trap by mocking foreign-key-to-Postgres-only-tables, not by creating those tables.
+
+### 4. MCP JWT key bootstrap needs both DEBUG=True AND empty private key file
+
+If your JWKS endpoint reads the signing key from disk in prod but generates an ephemeral one in dev mode, the test fixture needs BOTH `DEBUG=True` AND `MCP_JWT_PRIVATE_KEY_FILE=""` set. Otherwise the test tries to read a non-existent file and crashes during startup, not during the actual test.
+
+Recipe: set both env vars in the test fixture's `monkeypatch.setenv` block before instantiating the app.
+
+### 5. UserSubscription NOT NULL on stripe_customer_id
+
+If your User table joins to UserSubscription and UserSubscription declares `stripe_customer_id` as NOT NULL (because in prod every paying user has one), test fixtures inserting a free-tier user will fail constraint validation.
+
+Recipe: insert UserSubscription with a placeholder stripe_customer_id like `cus_test_<id>` for free-tier fixtures, or make the column nullable if the model supports it.
+
+## Self-destructing admin migration endpoint pattern
+
+For live DB changes that need to run once in prod without a full migration cycle:
+
+```python
+@router.post("/admin/migrations/<name>")
+async def run_migration_<name>(...):
+    # 1. Auth: require admin role + signed migration token
+    # 2. Idempotency: read a marker row; if present, return 200 "already ran"
+    # 3. Run the migration
+    # 4. Write the marker row
+    # 5. Log to audit_logs with full context (who, when, rows affected)
+    # 6. Return 200 with summary
+```
+
+Then delete the endpoint code in the next PR (self-destructing). The migration is recorded in audit logs; the marker row prevents re-runs; the endpoint is gone before the next contributor can re-invoke it.
+
+This pattern beats both "let's run a one-off script with the right env vars" (fragile, no audit trail) and "let's add a proper migration framework" (overkill for a one-off).
+
+## Deploy verification
+
+Cloud Run deploys complete in 2-4 minutes. After a merge, verify the deploy actually shipped your code:
+
+```bash
+# 1. Confirm the deploy workflow finished successfully
+gh run list --workflow="deploy.yml" --limit 1
+
+# 2. Fetch the live OpenAPI spec
+curl -s https://api.<your-domain>/openapi.json | jq '.paths | keys[] | select(test("<new-path>"))'
+
+# 3. If you added a docstring to a new endpoint, the FastAPI-generated spec
+#    will surface that docstring. Grep for it as a "yes, the new code is live" probe.
+curl -s https://api.<your-domain>/openapi.json | grep "<unique docstring phrase>"
+```
+
+The FastAPI docstring trick is the simplest "is my code actually deployed" verification. It works because FastAPI generates the OpenAPI spec from live introspection of the running app, not from a file in the repo. If the docstring is in the response, the new code is running.
+
+## Database backend
+
+When your DB is Supabase-hosted Postgres + GoTrue for auth:
+
+- Your team-lead (or whoever has the Supabase admin grant) is the only one who can do DB-level operations — migrations, role grants, RLS policy changes
+- Cloud Run instances connect via DATABASE_URL stored in Secret Manager
+- Console-level work (env vars, IAM, Secret Manager provisioning) often happens through the GCP console UI, not gcloud CLI
+
+If you can do GCP-console work but not Supabase-admin work, the boundary matters: route DB-level work (psql migrations against DATABASE_URL, dashboard ops) to whoever owns Supabase admin, keep Cloud Run / env / IAM in your lane.
+
+## Related
+
+- [consultant-connector-audit §14](../consultant-connector-audit/) — when a consultant pushes auth/billing/security code, the same audit discipline applies even though "connector" is in the name
+- [mcp-architecture](../mcp-architecture/) — the consumer side of the JWT contract this API issues

--- a/hermes/skills/engineering/consultant-connector-audit/index.md
+++ b/hermes/skills/engineering/consultant-connector-audit/index.md
@@ -1,0 +1,355 @@
+---
+title: consultant-connector-audit
+description: Full-stack audit pass that MUST run before shipping any fix on a connector authored by a non-core contributor. Replaces the fix-forward-on-symptom anti-pattern with one inventory + one PR. The single highest-leverage skill for any team running a multi-connector substrate.
+---
+
+# Consultant Connector Audit
+
+## When to invoke
+
+Any one of:
+
+1. A connector under your data adapter layer was authored by someone other than the core team, AND you've just hit at least one bug in it in production.
+2. A customer-facing surface has reported a connector failure that traces to non-core code.
+3. You're about to merge a new contributor-authored connector PR (preempt — audit BEFORE merge, not after the first customer-reported bug).
+4. CI failed in any way related to that connector (silent import, registry parity, formatting that masks a real bug).
+5. A contributor claims they "fixed" something in auth, billing, security, MCP routing, the token store, or any non-connector code path. Same discipline applies — verify the claim before nodding.
+
+If trigger 1 or 2 fires, **stop the fix-forward instinct.** Do not push a fix for the symptom you just saw. The cost of "one more PR" is not engineering time, it is the customer's perception of churn. Read the rest of this skill, run the audit, file ONE issue with the full bug inventory, fix in ONE PR, then tell the affected human "try again."
+
+## The Mailchimp pattern (the bug class this prevents)
+
+A real incident on the team's connector substrate, captured here so the pattern stays visible:
+
+| # | What broke | Trigger |
+|---|---|---|
+| 1 | `from config.kv_mixins` typo (module doesn't exist) | Customer demo hits the Connect button, 404 |
+| 2 | TokenManager.save_token missing required argument | Customer retried |
+| 3 | Adapter __init__ signature mismatch | Customer retried |
+| 4 | NameError: secrets in OAuth callback (affected 3 connectors at once) | Customer retried |
+| 5 | Adapter has no `close` method, breaks async cleanup | Customer retried |
+| 6 | Tokens written to local disk, not central secret store (constitution violation) | We noticed during 5's work |
+| 7 | 40 of 43 tools named with consultant nickname instead of canonical | Team noticed |
+| 8 | Same 40 tools missing from raw HTTP `tools/list` path | Team noticed |
+| 9 | Dev deploy stuck on lint after rushed direct-to-main commit | Team noticed |
+
+**Nine round-trips. Every single bug existed in the code at the moment of the first bug-fix PR.** A single 30-minute audit pass after bug #1 would have surfaced the full inventory; one PR, one "try again" call to the customer instead of nine, one "this product appears to be on fire" perception averted.
+
+## The audit checklist
+
+Run every item, in order, against the target connector. For each finding, append to a single Markdown checklist — do NOT open issues per-finding, that recreates the churn.
+
+### 1. Import & loader (the silent-failure surface)
+
+Does the auth module import cleanly in isolation? Does the adapter? What's in the try/except wrapper in your server entry point — does it log the import failure visibly, or swallow it?
+
+Findings:
+- [ ] Imports use canonical paths, not made-up paths
+- [ ] The try/except in the server entry logs the import failure at WARNING with the full exception — never silent
+- [ ] The connector's `<CONNECTOR>_AVAILABLE` (or equivalent) flag is truthy in a normal dev shell
+
+### 2. Token storage (constitutional)
+
+If you have a token-storage mixin or shared pattern (file + secret store dual-write, etc.), verify the connector actually uses it:
+
+- [ ] TokenManager inherits the canonical mixin (not a re-implemented one)
+- [ ] `save_token` / `load_token` / `delete_token` each call the corresponding helper method
+- [ ] The connector-naming constant (KV suffix, secret prefix, etc.) is canonical — not the contributor's nickname for the connector
+- [ ] Tokens actually land in the central store after a connect test — verify with the store's CLI directly, don't trust the code path
+
+### 3. Connector-method signatures match the dispatch layer
+
+The contributor's adapter `__init__` may take different args than the server.py dispatch passes. Common drift: positional vs kwarg, missing per-vendor optional params, extra `creds` parameter, sync vs async mismatch.
+
+- [ ] `__init__` signature matches every call site
+- [ ] `close()` exists and is `async` if dispatched from the async path
+- [ ] `save_token` / `load_token` are async if your loader awaits them directly
+
+### 4. Tool naming + registry parity
+
+If you have a registry that lists tools per connector AND each connector's tool file declares `Tool(name=...)` entries, run the parity test that diffs the two. Plus a manual sanity check on naming convention:
+
+- [ ] Every tool name matches `(get|search|list|delete|update|run)_<canonical_connector>_<noun>` — NOT `get_<consultant_nickname>_*`
+- [ ] Registry's `tools[]` and `tool_schemas{}` keys match each other
+- [ ] Every tool exists as a real `Tool(name=...)` entry in code
+
+### 5. HTTP `tools/list` exposure (the dual-path trap)
+
+Connectors can be visible via dynamic-manifest (one client path) but invisible via raw HTTP `tools/list` (another client path). Both must work.
+
+**Naming-convention warning before you write a parity check:** different client paths may use different name shapes for the same tool (full names like `get_klaviyo_campaigns` on one path, prefix-stripped `get_campaigns` on another). A naive set-equality diff between paths will flag 100% of connectors as broken. Normalize both sides by stripping the connector token before diffing.
+
+- [ ] Raw HTTP `tools/list` returns the expected count (i.e. all of them, not 3 of 43)
+- [ ] Mega-tool / dynamic-manifest path exposes the same count
+- [ ] Counts match between paths
+
+### 6. Vendor error surfacing (TWO layers — both required)
+
+Constitutional rule: vendor text errors (`ERROR NNN::MSG`, error JSON, `{"type":"...","status":4xx}`) must be hoisted to exceptions and surfaced as explicit error envelopes — NOT coerced to empty `{"data": []}` results AND NOT swallowed by the outer dispatch fall-through as `{"raw": null}`.
+
+This is a TWO-layer check. The adapter raising correctly is necessary but not sufficient; the dispatch elif-block must catch that typed exception or the outer `except Exception` will log it and silently leave `tool_result = None`, which the widget formatter ships as `{"raw": null}`.
+
+- [ ] **Layer 1 (adapter):** every HTTP call is followed by a vendor-error check; on error the adapter raises an explicit typed exception with status + resource + hint
+- [ ] **Layer 2 (dispatch):** the connector's elif-block in the HTTP dispatch wraps its tool calls in `try/except <Typed>Error` and sets `tool_result = {"error": ..., "hint": ...}` on catch
+- [ ] **Smoke test:** invoke a tool against a healthy account that should error. Response must be a structured envelope, NEVER `{"raw": null}`
+
+### 6.5. Per-resource access-token plumbing
+
+For vendors with sub-resource tokens (Facebook Pages, Slack bot vs user, Shopify shop-scoped, Google service-account vs delegated, GoHighLevel agency vs sub-account):
+
+- [ ] If the vendor has per-resource tokens, the adapter accepts/caches/looks up that token rather than reusing `self.access_token` for every call
+- [ ] The list-the-resources call captures the per-resource token in its return shape
+- [ ] Smoke uses an account with at least one real piece of content on the sub-resource (empty results on a healthy resource is the canary)
+
+### 7. Test value-level, not shape-level
+
+Antipattern: `assert result["record_count"] == 2` passes even when the column mapping is wrong. Real test: `assert result["data"][0]["keyword"] == "expected value"`.
+
+- [ ] At least one test per list-returning tool asserts a VALUE on row 0, not just `len()` or `record_count`
+- [ ] OAuth callback test asserts the token landed in the central store with the right shape
+- [ ] Adapter signature test exists — the kind that would have caught bug #3 instantly
+
+### 8. OAuth redirect URI matches the vendor portal
+
+Lesson from a real consultant pass: the contributor registered `https://mcp.example.com/oauth/<provider>/callback` in the vendor portal, but the infrastructure actually serves at `https://mcp2.example.com`. Result: 404 even after the code fix because the vendor portal was wrong.
+
+- [ ] Vendor portal redirect URI is your PROD host exactly — verified by logging into the vendor portal directly, NOT by trusting the contributor's commit message
+- [ ] If dev testing is needed, the vendor app supports multiple redirects OR there's a dedicated dev app
+- [ ] The `redirect_uri` in `auth/<connector>_auth.py` matches what's in the vendor portal exactly (including trailing slash, host, scheme)
+
+### 8b. Scopes — what the live authorize URL actually sends (dual-defaults trap)
+
+Caught on a real Facebook Pages/IG extension: the PR correctly extended scopes from 5 → 10 in `auth/facebook_auth.py`, but `config/settings.py` ALSO defined a `facebook_scopes` field with its own default — in TWO places (the dataclass default AND the `os.getenv` fallback), both with the stale 5-scope string. The auth-module default was dead code; the settings one always won. Every connect produced an Ads-only token; every new Pages/IG tool would have 403'd silently.
+
+The 30-second diagnostic that catches this: **fetch the live authorize URL and read its `scope=` parameter.** Don't trust grep on `auth/<connector>_auth.py` alone.
+
+- [ ] Live authorize URL's `scope=` parameter contains every scope the connector's tool surface actually needs
+- [ ] There is exactly ONE source-of-truth scope string. If config and auth both carry a default, they MUST match — preferably collapse to one
+- [ ] The env-var fallback matches the source-of-truth default (silent killer: prod containers without the env var set)
+- [ ] A regression-guard test exists asserting the live URL emits the full scope set
+
+### 9. Vendor app-review / scope approval status
+
+Discovered on a Facebook Pages + IG Business extension: tools wired cleanly, registry parity passed, dev+prod both green — but the OAuth scopes the new tools required weren't yet approved on the vendor app. Customers connecting via the standard flow hit "scope not authorized" or got empty results on the gated endpoints. **"Shipped" in code-land ≠ "usable by customers."**
+
+#### Scope-PRESENCE ≠ scope-TRAFFIC (Meta dashboard gotcha)
+
+Meta's App Dashboard tracks **call traffic per scope**, not just whether the scope is in your token grant. Two distinct things can fail audit:
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| Scope shows zero calls but feature appears to work in your test | Scope is granted (in token) but no API endpoint you hit "counts" toward it. Meta attributes each call to its **most-specific** parent scope. | Add a tool that hits the scope's canonical endpoint. For `public_profile` that means a literal `/me?fields=id,name,email` — `/me/accounts` counts toward `pages_show_list`, not `public_profile`. |
+| Scope shows zero calls AND OAuth dialog never asked for it | Dual-defaults trap from §8b, OR scope was just missed entirely. | Add to defaults, re-OAuth to get a new token with the grant. |
+| Scope IS in token, IS being granted, IS in call URL, reviewer rejects | App Review needs **observed traffic from a test user**, not just code paths that could theoretically call it. | Exercise the tool against a real test account multiple times at least 24h before submission. |
+
+- [ ] For every scope in the connector's scope list, check the vendor portal: `Approved`, `In Review`, or `Available with restrictions`?
+- [ ] If any scope is unapproved, the audit issue MUST list it explicitly, and customer-facing messaging MUST NOT say "shipped" without qualification
+- [ ] Smoke against a real account YOU own BEFORE telling any customer the tools work
+- [ ] Honest framing: "tools live; X scopes pending vendor app review, customers will see Y behavior until approval lands (~N business days)"
+
+The cost of skipping this is shaped like the consultant-connector-bug cost — customer tries, fails, retries, fails — except worse, because there's no fix you can ship in 30 minutes. The fix is a 3-7 day vendor review cycle.
+
+### 9.5. Duplicate config-source trap (silent override)
+
+Pitfall surfaced on Facebook: PR added 5 new scopes to `FB_DEFAULT_SCOPES` in `auth/facebook_auth.py`, but `config/settings.py` had its OWN field with the old string. The auth code did `getattr(settings, "facebook_scopes", None) or FB_DEFAULT_SCOPES` — `settings.facebook_scopes` ALWAYS won because it's a real attribute, never None. `FB_DEFAULT_SCOPES` was dead code.
+
+For ANY connector-level constant (scopes, redirect URI, API base, version):
+
+- [ ] Exactly ONE source of truth. If two: the one in `config/settings.py` will win — confirm by reading the actual `getattr(...) or DEFAULT` site
+- [ ] When the contributor adds new values, they updated EVERY duplicate or deleted the duplicate
+- [ ] Live verification (§5/§8) is what catches this — never trust code-reading alone
+
+### 9.6. Parallel code path trap (refactor missed sibling)
+
+Pitfall surfaced on Mailchimp: a fix correctly made the inline `server.py` loader async-aware, and a separate PR migrated the TokenManager to sync helpers. But `auth/mailchimp_auth.py` had THREE helper methods doing `await self.token_manager.load_token(...)` — a parallel code path the inline fix never touched. Every tool call hit `TypeError: object dict can't be used in 'await' expression`.
+
+Recurred on a metric-spec ship: PR added contract strings to `server.py`'s data-contract render path. CI green, dev deploy green. First smoke against the deployed surface showed the directive MISSING — because the Claude-shaped render path is a near-duplicate in `openai_app/response_formatter.py` with its own override map. Server.py path was instrumented; openai_app path wasn't.
+
+**Mitigation pattern (generalizable):** when intentional duplication can't be collapsed to a single source without architectural lift, add a lockstep equality test that asserts the two copies are equal. Drift becomes a static problem (CI red on edit-one-copy) instead of a runtime one (silent ship, customer-visible).
+
+```python
+def test_X_constants_in_lockstep_across_render_paths() -> None:
+    """server.py and openai_app must carry IDENTICAL X strings.
+
+    They're duplicated by design (different render paths, can't share a
+    module without an architectural lift), so the only insurance against
+    drift is a test that pins equality. If you edit one, the test forces
+    you to edit the other.
+    """
+    from server import _X_CONSTANT_A, _X_CONSTANT_B
+    from openai_app.response_formatter import (
+        _OPENAI_X_CONSTANT_A, _OPENAI_X_CONSTANT_B,
+    )
+    assert _X_CONSTANT_A == _OPENAI_X_CONSTANT_A
+    assert _X_CONSTANT_B == _OPENAI_X_CONSTANT_B
+```
+
+If you are editing one of the left-column files, you almost certainly also have to edit its right-column twin. Audit FIRST, edit BOTH, ship ONE PR.
+
+| Concern | Path A (usually first instrumented) | Path B (the one that gets missed) | Lockstep guard |
+|---|---|---|---|
+| Token load/save/delete | `server.py` inline loader (async-aware) | `auth/<connector>_auth.py` helper methods (`get_access_token`, etc.) | None today — grep every `token_manager.(load|save|delete)_token` call site, confirm sync/async parity |
+| Per-tool data contract text | `server.py:_tool_data_contract_text` (stdio + raw HTTP path) | `openai_app/response_formatter.py:_build_data_contract` (Claude/widget path) | A test like the above — string-equality assertion forces CI break on drift |
+| Tool registration | `tools/<connector>_tools.py` (`Tool(name=...)`) | `config/connector_registry.json` (`tools[]` + `tool_schemas{}`) | Generalized parity test |
+| Tool dispatch | `server.py` async elif-block | `server.py` HTTP dispatch elif-block for the same connector | None — grep both for every `name == "<tool>"` branch on a new tool |
+| OAuth scope set | `auth/<connector>_auth.py:<CONNECTOR>_DEFAULT_SCOPES` | `config/settings.py:<connector>_scopes` (dataclass + env fallback) | §8b live-authorize-URL inspection |
+
+The duplication is intentional in most cases. The architectural cost of unifying them is high; the operational cost of leaving them un-mirrored is the §9.6 trap. Lockstep tests + this table are the cheap insurance.
+
+When you add a new sibling pair to this table, **add the lockstep test FIRST** so the table entry has a CI-enforced backing.
+
+### 10. Live tool invocation smoke (NEVER skip)
+
+Pitfall surfaced on Mailchimp (twice): "shipped" was claimed after verifying that tools appeared in `tools/list`. They did appear. They were also 100% non-functional at dispatch. Listing visibility is necessary but not sufficient. The customer hit the TypeError on the first real tool call.
+
+**Before any "shipped" / "fixed" / "ready" claim:**
+
+Get a JWT for a test user. Invoke at least ONE representative READ tool against the prod endpoint with that JWT. Confirm the response has actual data, not just an error envelope. For each connector, smoke at least one tool from each category present:
+
+- **Account/profile read** (`get_<x>_account`, `get_<x>_profile`) — easiest signal of dispatch health
+- **List read** (`list_<x>_<resources>`) — proves pagination/serialization
+- **Detail read** (`get_<x>_<resource>` with an ID from the list) — proves parameter passing works
+
+If the connector has write tools, do NOT smoke them in this audit. Stick to read-only.
+
+#### What's required to mark §10 clean
+
+| Result | Verdict |
+|---|---|
+| HTTP 200 + JSONRPC `result` + parseable JSON body + at least one expected field | ✅ clean |
+| HTTP 200 + `Tool <name> error: …` in `content[0].text` | ❌ **DISPATCH BUG** — usually means async path doesn't match adapter signature. Do NOT ship. |
+| HTTP 200 + auth-required envelope | ⚠ test user isn't authorized — re-auth and retry; not a code bug but smoke didn't complete |
+| HTTP 401/403 | JWT expired — refresh and retry |
+| HTTP 5xx | Container is unhealthy — separate issue |
+
+#### Pitfall: error envelopes inside HTTP 200 responses
+
+Many MCP servers wrap tool failures in `result.content[0].text` with the literal string `Tool <name> error: <message>`. The HTTP response is 200, the JSONRPC envelope has `result` not `error`, but the actual tool failed. **Always parse `content[0].text` and check for the error prefix** — do not stop at HTTP 200 or "JSONRPC result is present."
+
+#### Pitfall: auth-required envelope is partial §10 evidence, NOT full
+
+A successful smoke against an authenticated user is the whole picture. An auth-required envelope means dispatch wiring works (tool was found, gate fires cleanly) but the new vendor-facing code paths were never exercised. The honest status framing when you hit this:
+
+> "Shipped to prod: deploy green, tools dispatched cleanly on `/mcp/tools/list`, CI value-level tests cover the new code paths. Vendor-side verification (real call returning the new envelope shape) is owed to the next authenticated session — instructions for what to look for in the issue comment."
+
+Do not claim "fully verified end-to-end" without the real vendor response. Do not under-claim either — dispatch+CI is meaningful evidence, just not the whole picture.
+
+#### Pitfall: "Retrieved 0 results." is NOT a failure signal
+
+Some MCP wrappers inject a canonical data-contract footer into every tool response's `content[0].text` slot. It typically reads `Retrieved 0 results.\nData contract: ...\nPowered by <wrapper>`. **The real payload lives in `result.structuredContent.data`** — a dict with the actual adapter return value. A successful tool call shows `Retrieved 0 results.` in text AND has `structuredContent.data.<field> = <value>`. Do not flag the prose as failure; parse `structuredContent.data` and assert real fields.
+
+This is the single highest-value check in the audit. If you have time for only one, do this one.
+
+### 11. Dev AND prod deploy both green
+
+Lesson: a direct-to-main style commit can leave Development behind. Always check BOTH environments after any connector-affecting merge.
+
+- [ ] Last Development deploy is green
+- [ ] Last main deploy is green
+- [ ] `tools/list` on BOTH hosts returns the connector at expected count
+
+### 11.5. OAuth scope drift — verify stored token scopes BEFORE blaming code
+
+When a vendor connector returns "Application does not have permission" / "Invalid OAuth 2.0 Access Token" on tools that *should* work — and connector status says Connected, and the code looks right — **check the stored token's scope set BEFORE filing a code bug or delegating an audit**.
+
+Failure mode: a recent PR added a new scope to the OAuth request. Users who authorized BEFORE that PR have valid-but-stale tokens — the right scopes were never granted. Status reports green; API calls needing the new scope fail.
+
+**30-second diagnostic (Meta example):**
+
+1. Grab the `access_token=` query value from any leaking error envelope URL
+2. `GET https://graph.facebook.com/v21.0/debug_token?input_token=<T>&access_token=<T>`
+3. Diff returned `scopes[]` against what your tool needs. The diff IS the explanation.
+
+Generalize per vendor: Google = `tokeninfo` endpoint; Microsoft = decode the JWT; Slack = `auth.test` returns scopes header; Stripe = `ListPermissions`. Every major OAuth vendor exposes an introspection path.
+
+**Fix is operational, not code:** reset the user's token + OAuth re-consent. Zero PRs.
+
+**Add this as the FIRST check in any "this connector broke" investigation.** It goes BEFORE the code audit, BEFORE delegating a fix subagent, BEFORE reading server.py.
+
+### 12. Release-promotion PRs MUST cut from origin, not local
+
+Bit twice in one session. Pattern is identical and silent.
+
+**The trap (do NOT do this):**
+
+```bash
+git checkout main && git pull          # main is fresh
+git checkout -b release/X              # branch from local main
+git merge Development --no-edit        # ← local Development is STALE
+                                       #   (no `git pull` since the last
+                                       #    Development merge happened)
+git push -u origin release/X
+gh pr create --base main && gh pr merge --admin --merge
+# Deploy goes green. Image SHA changes. Container restarts.
+# Code on prod is UNCHANGED because the merge had nothing to merge.
+```
+
+**The fix:**
+
+```bash
+git fetch origin -q
+git checkout -b release/X origin/Development   # cut DIRECTLY from remote
+git push -u origin release/X
+gh pr create --base main ...
+```
+
+The `git checkout -b release/X origin/Development` form sidesteps the trap entirely — there's no local Development branch in the equation, so it can't be stale.
+
+**Pre-promotion verification (catches the trap if you forget):**
+
+```bash
+# This should be NON-EMPTY for any file the new PRs touched
+git fetch origin -q
+git diff origin/main..origin/Development -- <changed_file_path>
+# If empty when you expect changes, local Development is stale.
+# Re-cut release branch from origin/Development directly.
+```
+
+**Why this fails silently:** the merge produces zero diff, the PR shows green CI, the deploy workflow ships the new commit SHA, the container restarts cleanly. Every signal says "shipped." But `git show <deploy_sha>:<changed_file>` returns the OLD bytes because the deploy SHA points to a merge commit with no changes underneath it. You only catch the failure when you actually invoke the tool and see the bug you just "fixed" still present.
+
+**Pre-flight check for §11 deploy verification:** before declaring deploy green, confirm the deployed image SHA's bytes match what you intended to ship — not just that the workflow run reports success. The image-SHA-to-bytes check is mechanical (one git command) and catches both this trap and the rarer case where the deploy step itself shipped a stale build artifact.
+
+### 13. Multi-round audits are not churn (vs the Mailchimp anti-pattern)
+
+A single audit cycle CAN legitimately produce N rounds of fix-then-re-exercise, with each round revealing previously-hidden defects that the prior fix exposed. **This is not churn.** The discipline distinction:
+
+| Anti-pattern (Mailchimp) | Healthy multi-round audit |
+|---|---|
+| Customer hits bug → fix bug → push → customer hits NEXT bug → repeat | Customer hits bug → run full audit → file ONE issue with N findings → ship ONE PR for all N → re-exercise → if new findings emerge, file ONE issue + ship ONE PR for them |
+| Each round = one symptom-driven hotfix | Each round = one full-audit-driven consolidation |
+| Customer-perceived "this product is on fire" | Internal "iterative discovery, each shipped cleanly" |
+| Caused by skipping audit | Caused by AUDIT finding new things only the previous fix could expose |
+
+**When in doubt:** if you've shipped 3+ PRs in one session for the same connector AND each one carried a single finding AND the user was the trigger ("retry"), STOP and run the full audit. If you've shipped 2-3 PRs AND each carried multiple findings AND the trigger was re-exercise revealing newly-reachable defects, you're on the healthy multi-round path.
+
+## After the audit: file ONE issue, ship ONE PR
+
+The output is a single GitHub issue titled `<Connector> connector audit — N findings`, body is the full checklist with every finding marked done/issue/n-a, and a `## Proposed fix plan` section listing every code change needed.
+
+Then open **one** PR that addresses every finding. Even if the PR touches 10 files. The cost of "one big PR" is review time; the cost of "ten small PRs" is customer-perceived churn. The former is bounded and internal; the latter is unbounded and external.
+
+The PR description must enumerate which audit findings it closes, and the PR must include the value-level tests from §7 above as regression guards.
+
+## Personnel comms after a process finding
+
+When the audit surfaces a process issue tied to an external collaborator — direct-to-main push, missed PR, no-tests-on-shipped-code, or any pattern that crosses into "the contributor should have done X" territory — file the technical fix and the regression-test PR as normal AND surface the process finding to your team lead in writing. **Do NOT initiate outbound comms to the contributor about the process issue.** Personnel-flavored conversations belong to the team lead.
+
+The two are separate channels: the audit fix lands as normal engineering work via PR; the personnel conversation about *how* the change was shipped is the lead's. Offering to draft the contributor note is fine; sending it without explicit go-ahead is not.
+
+## Before saying "try again" to the human
+
+Don't ping the customer with "fixed, try again" until you've done the human's flow yourself. Concretely:
+
+1. Get a fresh JWT for a test user
+2. Hit the actual `/connect?connector=<connector>` endpoint, follow the redirect chain to `/oauth/<connector>/authorize`, confirm 302
+3. After OAuth completes, call the dynamic-manifest mega-tool AND the raw `tools/list` from the same client
+4. Invoke one representative read tool against a real account (or the test account if vendor allows)
+5. Only then send the "try again" message — and frame it as "verified end-to-end on prod with my own test account, here's what to expect" not just "PR merged"
+
+If you can't verify end-to-end (no test account, vendor portal blocks dev), the honest framing is "fix shipped, I couldn't fully verify because of X — please test and let me know what you see." Not "try again."
+
+## When to merge a contributor PR going forward
+
+Run this checklist BEFORE clicking merge on any contributor PR introducing or touching a connector. The audit on a fresh contribution catches the same bugs but BEFORE the customer hits them. The 30 minutes you spend on the checklist is the cheapest insurance available.
+
+If the contributor pushes back ("this is overkill for a small change"), the right answer is the Mailchimp inventory above. Nine round-trips and a damaged customer relationship is what the alternative costs.

--- a/hermes/skills/engineering/frontend-development/index.md
+++ b/hermes/skills/engineering/frontend-development/index.md
@@ -1,0 +1,73 @@
+---
+title: frontend-development
+description: Pattern for a Next.js + Tailwind frontend that serves BOTH a public marketing site and an authenticated customer dashboard from the same repo. Vercel auto-deploy, the canonical-constant rule for shared values, npm build's public/ writeback gotcha, and the deploy-verification boundary.
+---
+
+# Frontend Development (Next.js + Vercel)
+
+When a single Next.js repo serves BOTH the public marketing site (`www.<domain>/*`) AND the authenticated customer dashboard (`/dashboard/*`), the discipline shifts compared to either alone. This skill covers the patterns that bite once you have both surfaces in one codebase.
+
+## The single-repo, two-surface architecture
+
+- Marketing routes: `/`, `/pricing`, `/connectors`, `/blog`, etc. — public, SEO-critical, indexed by Google
+- Dashboard routes: `/dashboard/*` — authenticated, behind a session cookie, the actual product UX
+- The BFF layer (`/api/*` Next.js routes) wraps your backend API and handles cookie-based session state — the API itself never sets cookies, the frontend does
+- Vercel auto-deploys every push to main — one push, both surfaces redeploy
+
+The trap: a copy-edit to a pricing page on the marketing side and a UX change to the dashboard land in the same Vercel deploy. If either breaks, both go down. Watch deploy status after EVERY push, not just dashboard PRs.
+
+## The canonical-constant rule
+
+A real failure mode: someone added a connector to the connector substrate, also added it to the dashboard's connector list (good), but the marketing site's `/connectors` page is generated from a separate constant file (bad). Customers visit the marketing page, see the connector listed, try to connect from the dashboard — and the dashboard shows it as Connected (because the marketing page wasn't the source of truth). Or worse, the marketing page does NOT show the connector, customers don't know it exists, the dashboard offers it but nobody knows.
+
+**The rule:** any value that appears on BOTH surfaces (connector count, pricing, feature lists, plan tiers) has exactly ONE source of truth, imported by both surfaces. If you find yourself updating the same string in two files, you've found a canonical-constant violation.
+
+Audit pattern: grep your repo for the value before changing it, confirm it appears in only one place.
+
+## npm build's `public/` writeback gotcha
+
+If your build script writes generated files into `public/` (e.g. sitemap.xml, OG images, schema.json), AND those generated files are committed to git, you'll get a recurring "uncommitted changes after build" problem on local dev.
+
+Solutions, in order of preference:
+1. Add the generated files to `.gitignore` and regenerate on deploy (preferred)
+2. Build into a separate directory, copy to `public/` only in CI
+3. If they MUST be committed, run the build once after every change and commit the artifact along with the source
+
+The third option drifts silently — the build's output and the committed artifact eventually diverge and the deployed site shows stale generated content.
+
+## Deploy verification — the marketing-site-specific check
+
+After any push that touches a customer-visible marketing surface (new connector, pricing change, new page):
+
+```bash
+# 1. Wait for Vercel to finish (typically 90s-3min)
+# 2. Fetch the live page directly
+curl -s https://www.<your-domain>/<page> | grep <new-thing>
+
+# 3. If the marketing site's CMS / data layer is in a different repo, ALSO check there
+# Common pattern: MCP server ships a connector → marketing site (separate repo) needs a
+# matching entry. The MCP merge does NOT update the marketing site repo.
+```
+
+The MCP-server-changes-don't-update-marketing-site trap bites hard. Customer reads marketing site, sees old connector list, tries new connector, hits "connector not found." You shipped the platform change but the marketing site is wrong.
+
+## Author email mapping (Vercel auto-deploy quirk)
+
+If your Vercel project is configured to auto-deploy on push from specific authors, a contributor's commit may NOT trigger auto-deploy under their identity. The fix is usually manual: someone with the Vercel admin role hits "Redeploy" in the dashboard.
+
+When you (the agent) push a fix to the frontend repo and the deploy doesn't fire automatically, the honest framing in your status update is: "PR merged at <SHA>. Vercel auto-deploy may not have fired because of author-email mapping; please click Redeploy in the Vercel dashboard if you don't see it deploying within 2 minutes." Don't claim "deployed" without verifying the deploy actually happened.
+
+## Cross-repo boundary
+
+If your marketing copy lives in this repo but your blog posts, knowledge base, or product docs live in a DIFFERENT repo (common when the docs site is a separate Vercel project), the boundaries:
+
+- Changes to marketing routes (homepage, /pricing, /features) — this repo
+- Changes to /blog or /docs — usually the other repo
+- Connector listings: depends on the project — some teams put the canonical list in the docs repo and import it here; some put it here and link from docs. Confirm before editing
+
+When in doubt, grep the deployed page for a unique string and see which repo's git log mentions it most recently.
+
+## Related
+
+- [mcp-architecture](../mcp-architecture/#marketing-site-is-a-separate-repo-verification-trap) — the MCP-server-side view of the same cross-repo boundary
+- [api-development](../api-development/) — the BFF layer's backend dependency

--- a/hermes/skills/engineering/honcho-memory-usage/index.md
+++ b/hermes/skills/engineering/honcho-memory-usage/index.md
@@ -1,0 +1,87 @@
+---
+title: honcho-memory-usage
+description: When and how to read/write Honcho via the honcho MCP server — server-side semantic memory that complements (does not replace) MEMORY.md and USER.md. The cold-storage pattern that survives session reset.
+---
+
+# Honcho Memory Usage
+
+Honcho is a server-side semantic memory store wired into Hermes as an **MCP server**, NOT as the active memory provider. The built-in MEMORY.md + USER.md remain the hot path (injected into every system prompt for free). Honcho is the cold path: server-side semantic store you query on-demand via tool calls.
+
+## Mental model
+
+| Layer | What it holds | Cost | Latency |
+|---|---|---|---|
+| MEMORY.md / USER.md | ~12KB hand-curated declarative facts | injected every turn (in token bill) | zero — already in prompt |
+| Skills | Procedural runbooks loaded on demand | one tool call when loaded | ~1s |
+| session_search (SQLite FTS5) | Past conversation transcripts | one tool call | ~100ms local |
+| **Honcho (this skill)** | Semantic representation built from messages we explicitly write | one MCP roundtrip + Honcho processing | ~500ms-2s per call |
+| Honcho `chat` (dialectic) | Theory-of-mind queries against the representation | model call inside Honcho | ~2-5s |
+
+Honcho is empty by default. It only knows what we tell it. Querying an empty workspace returns nothing useful — by design.
+
+## When to WRITE to Honcho
+
+The bar for writing is high. Most "save this" instincts should go to MEMORY.md instead. Honcho is for facts that:
+
+- Are **too verbose for the prompt budget** (multi-paragraph context, longer narrative facts)
+- Require **semantic search** to retrieve (you'll query by intent, not by key)
+- Survive **across sessions** but don't need to be in every turn's context
+
+Examples that belong in Honcho:
+- "The 2026-06-10 architecture review decision: we picked Cloud Run over Lambda because of cold-start latency in the auth flow. Here's the full reasoning..."
+- "Detailed customer profile facts: their team structure, their security posture, their tooling preferences, the specific objections they've raised over four calls"
+- "Long-form vendor-specific lessons: every gotcha we hit during the Stripe integration over six months"
+
+Examples that belong in MEMORY.md instead:
+- "User prefers concise responses"
+- "Project uses pytest with xdist"
+- "Server-local time is GMT-7"
+
+If you can express the fact in one sentence and it'll be useful every session, MEMORY.md. If it's multi-paragraph and you'll search for it semantically, Honcho.
+
+## When to READ from Honcho
+
+Read when:
+- A topic comes up that you suspect has substantial prior context
+- The user references a past decision you don't have in MEMORY.md
+- You're starting work on a domain where Honcho might have stored context (e.g. "let's pick up the Stripe migration" → query for Stripe-related facts)
+
+Don't read on every turn — Honcho roundtrips cost real latency. Use it like a card catalog, not like a system prompt.
+
+## API shape (MCP-exposed tools)
+
+The Honcho MCP server exposes (depending on configuration):
+
+| Tool | Purpose |
+|---|---|
+| `mcp_honcho_add_messages_to_session` | Append messages to a session (the substrate Honcho builds the representation from) |
+| `mcp_honcho_query_conclusions` | Semantic search over derived conclusions (facts/observations about a peer) |
+| `mcp_honcho_chat` | Natural-language Q&A against the representation ("what does Honcho know about <topic>?") |
+| `mcp_honcho_get_peer_card` | Compact biographical fact list |
+| `mcp_honcho_get_peer_context` | Combines representation + peer card |
+| `mcp_honcho_create_conclusions` | Manually inject conclusions (use for facts not derived from messages) |
+
+## Workspace + peer naming
+
+Each Hermes profile maps to a Honcho **workspace**. Multiple agents/sessions inside the same profile share a workspace. The **peer** identifies a single real human — typically the user's email or a stable identifier.
+
+Confusing the boundary leads to "I queried Honcho and got nothing useful" — usually because you queried the wrong workspace or wrong peer.
+
+## Cost discipline
+
+Honcho is not free. Each `chat` call invokes a model inside Honcho's substrate, so:
+
+- Default reasoning level: `low` or `medium` for most queries
+- Use `high` or `max` only when the query is genuinely complex and the answer matters
+- `query_conclusions` is cheaper than `chat` — prefer it when you want raw matched facts, not a synthesized answer
+
+## When NOT to use Honcho
+
+- You're trying to remember WHAT happened in a past session — use `session_search` against the local SQLite FTS5 store. Honcho's job is "what does Hermes know about the user/topic," not "what did we discuss on Tuesday."
+- The fact is a one-liner — use MEMORY.md.
+- You're building procedural knowledge ("how to do X") — use a skill, not Honcho.
+- You need the fact in every turn's prompt — use MEMORY.md.
+
+## Related
+
+- [scheduled-jobs](../scheduled-jobs/) — cron jobs that need cross-session memory often want Honcho rather than ad-hoc state files

--- a/hermes/skills/engineering/index.md
+++ b/hermes/skills/engineering/index.md
@@ -1,0 +1,61 @@
+---
+title: Engineering Skills
+description: Skills for building and maintaining the CorpusIQ platform — MCP servers, connector substrates, multi-repo coordination, and the discipline that keeps a 51k-LOC server.py from rotting silently.
+---
+
+# Engineering Skills
+
+These are the skills for **building** the platform, distinct from `development/` which covers using the platform (GitHub PR mechanics, code review, repo management).
+
+Born from operating a multi-connector MCP server through customer pull, vendor API churn, and consultant-authored contributions that needed audit before merge. Each one captures a pattern earned the hard way — a class of bug that bit, the audit that surfaced it, and the discipline that prevents recurrence.
+
+**Single most important pattern:** when a consultant or non-core contributor ships connector or auth code, run the audit before clicking merge. The cost of "one more PR" is not engineering time — it is the customer's perception of churn. The Mailchimp 9-PR cycle that gave birth to half these skills was nine round-trips of "Ben hits bug → I fix bug → Ben hits NEXT bug." A 30-minute audit after the first bug would have shipped everything as one PR.
+
+## Connector & MCP Discipline
+
+| Skill | What It Does |
+|-------|-------------|
+| [`consultant-connector-audit`](./consultant-connector-audit/) | 13-section audit for any non-core-authored connector. The single most-loaded skill in this section — catches Mailchimp-style silent-failure clusters before they ship to customers. |
+| [`mcp-architecture`](./mcp-architecture/) | Orientation for a 50k+ LOC MCP server: file map, per-connector triplet pattern, bulk-regex migration recipe, dual-render-path trap (server vs ChatGPT app). |
+| [`metric-spec-registry`](./metric-spec-registry/) | The "metric spec waterfall" — when two systems disagree about MRR, the registry's drift report tells you which one to trust and why. |
+
+## Repo & Platform Coordination
+
+| Skill | What It Does |
+|-------|-------------|
+| [`api-development`](./api-development/) | Cloud Run + Supabase patterns, FastAPI test-fixture recipe (JSONB compile hook ordering, UUID type matching, MCP JWT key bootstrap). Born from a real consultant audit. |
+| [`frontend-development`](./frontend-development/) | Vercel deploy parity rules, marketing-site discipline, dashboard widget patterns, the "marketing site is in a separate repo" verification check. |
+| [`scheduled-jobs`](./scheduled-jobs/) | Cron operating manual: server-local time (not UTC), gateway architecture, in-prompt-curl trap, deliver-script pattern. |
+
+## Cross-Session Memory
+
+| Skill | What It Does |
+|-------|-------------|
+| [`honcho-memory-usage`](./honcho-memory-usage/) | When and how to read/write Honcho across sessions. The substrate-level memory pattern that survives session reset. |
+
+## Why These Are Distinct From `development/`
+
+The `development/` section covers tools every dev uses: GitHub PRs, code review, repo cloning, syntax checks. Generic, well-trodden, mostly automatable.
+
+These are different. They're the patterns that emerge when you operate a customer-facing platform at the size where:
+
+- One silently swallowed error compounds into nine PRs of churn
+- A consultant who didn't write to your constitution introduces a connector that passes CI but breaks at first customer call
+- Two systems (server-side vs ChatGPT mega-tool) compute "the same number" differently and you have to figure out which one is wrong
+- Branch protection rules, release-promotion discipline, and image-SHA verification turn into the difference between "shipped" and "actually changed prod"
+
+Every skill here is a fence around a hole the team already fell into. Read them when you're about to do the thing they describe; patch them immediately when the hole moves.
+
+## Naming Conventions
+
+- Skills with patterns generalizable to any MCP / connector / multi-repo team: no prefix (`consultant-connector-audit`)
+- Skills specific to CorpusIQ infrastructure (paths, vendor IDs, internal tools): prefixed `corpusiq-*` in the source profile, but stripped here when contributed
+- References to specific PR numbers, customer incidents, or internal vendor IDs in the original skills have been generalized for this section — the PATTERN is the value, the specific repo paths are noise
+
+## Source
+
+These skills are maintained in the CorpusIQ engineering agent's Hermes profile. Updates land here via PR.
+
+---
+
+*← [Skills Overview](/hermes/skills/) | [Catalog](/hermes/skills/catalog/) → | ↑ [Home](/hermes/)*

--- a/hermes/skills/engineering/mcp-architecture/index.md
+++ b/hermes/skills/engineering/mcp-architecture/index.md
@@ -1,0 +1,165 @@
+---
+title: mcp-architecture
+description: Field guide for operating a 50k+ LOC MCP server with multi-connector substrate. Where files live, the per-connector pattern, deployment topology, dual-render-path traps, and the discipline that keeps it from rotting silently.
+---
+
+# MCP Architecture — operating-scale orientation
+
+A skill for the team building and maintaining an MCP (Model Context Protocol) server with 30+ connectors, multiple client paths (stdio, raw HTTP, ChatGPT mega-tool), and the operational discipline that comes with serving real customer traffic through it.
+
+This is not "how MCP works" — that's covered by Anthropic's MCP docs. This is "how to keep a customer-facing MCP server from rotting in 50,000+ lines."
+
+## Endpoint topology — there are usually only TWO backends
+
+Most multi-environment MCP deployments have **exactly two distinct backends** (dev + prod), but often **three+ hostnames** resolve to them because:
+
+- ChatGPT app submissions pin a hostname at approval time; rather than re-submit/re-verify, the team aliases the old hostname to prod
+- DNS migrations leave behind aliases
+
+Get this wrong in customer/exec comms and you'll claim "deployed to three environments" when you actually mean two. The lesson came from a misframed announcement email.
+
+**Implications:**
+- For customer/exec comms — use two-environment framing: "dev (`mcp-dev`) and prod (`mcp`)." Never describe an alias as "legacy dev" or imply it's separate
+- For verification — probing a hostname and its alias returns identical results by design. Listing them as separate verifications is redundant noise, not extra coverage. Verify against the canonical dev hostname for dev, canonical prod hostname for prod, full stop
+
+## The per-connector triplet
+
+For every connector you maintain, you have (at minimum) three files:
+
+```
+auth/<connector>_auth.py              # OAuth or credential paste, TokenManager
+data_sources/<connector>_adapter.py   # HTTP client, vendor methods
+secure_workspace_mcp/tools/<connector>_tools.py   # Tool() schemas
+```
+
+Plus dispatch wiring in `server.py` and registry entries in `config/connector_registry.json`. The registry parity test (see [consultant-connector-audit](../consultant-connector-audit/) §4) enforces that the registry and the tool files agree.
+
+When a connector author skips one of these three files, you get a "tool exists in registry but no real implementation" silent failure that only surfaces when a customer invokes the tool. The audit catches it at PR time, not customer time.
+
+## Credential-paste connectors (Path A)
+
+For OAuth connectors (HubSpot, QuickBooks, Shopify, etc.) the OAuth flow handles the connection UX. For credential-paste connectors (Stripe, Semrush, GunBroker, API-key databases, BYOK), **the credential-store methods on your server class are NOT enough.** You must also register HTTP routes in both API files so the user can actually hit a setup form.
+
+### The failure mode this prevents
+
+Real bug: a Phase 1 PR shipped a full credential-paste connector (adapter + auth + tools + 4 server-class credential methods + error payload pointing users to `/api/v1/<x>/connect`)... but **zero HTTP routes were registered.** User clicks Connect → 404 Not Found. The credential-store methods were orphaned in Python — callable from the codebase, invisible over HTTP. Lived in production for a month.
+
+### The required routes
+
+Mirror an existing credential-paste connector's route block. For our pattern, that's 5 routes per API file:
+
+```
+GET    /api/v1/<x>/connection   → get_<x>_connection      (masked status JSON)
+POST   /api/v1/<x>/connection   → set_<x>_connection      (save credentials, JSON body)
+DELETE /api/v1/<x>/connection   → delete_<x>_connection   (remove credentials)
+GET    /api/v1/<x>/connect      → get_<x>_connect_help    (HTML setup form)
+POST   /api/v1/<x>/connect      → get_<x>_connect_help    (same handler, processes form submit)
+```
+
+Plus 5 mirror routes under `/api/v2/custom-app/<x>/...` for the ChatGPT Actions path.
+
+### Audit checklist for every credential-paste connector PR
+
+```bash
+# Should be ≥5 (3 connection + 2 connect routes)
+grep -c "/api/v1/<name>/" api/rest_api.py
+
+# Should be ≥5 (same shape, v2 prefix)
+grep -c "/api/v2/custom-app/<name>/" api/custom_app_api.py
+
+# Should be 4 handlers per file
+grep -c "async def \(get\|set\|delete\)_<name>_\|async def get_<name>_connect_help" api/rest_api.py
+grep -c "async def \(get\|set\|delete\)_<name>_\|async def get_<name>_connect_help" api/custom_app_api.py
+```
+
+If any count comes back zero or low, you've shipped an orphaned credential store. The connector-status response will still cheerfully tell users where to connect — but the URL will 404.
+
+## Dual-render-path trap (server.py vs ChatGPT app)
+
+Symptom: a feature ships, CI green, dev deploy green, you smoke against the deployed surface and the new behavior is **missing** from the response.
+
+Pattern: many MCP servers serving both raw `tools/list` clients (Claude desktop, stdio, raw HTTP) AND ChatGPT mega-tool clients have two render paths for response wrapping:
+
+| Path | File | Reaches |
+|---|---|---|
+| stdio + raw HTTP path | `server.py:_tool_data_contract_text` | Claude desktop, raw MCP clients, ChatGPT mega-tool body |
+| Claude/widget path | `openai_app/response_formatter.py:_build_data_contract` | Claude.ai, VS Code Insiders, widget-aware clients |
+
+Adding a render directive to one path and not the other ships a feature that's invisible to half your customers.
+
+**The fix is architectural debt management, not code:** when intentional duplication can't be collapsed to a single source, add a **lockstep equality test** that asserts the two copies are equal. CI red on edit-one-copy is the durable fix. Pattern below; full discussion in the [consultant-connector-audit §9.6](../consultant-connector-audit/#96-parallel-code-path-trap-refactor-missed-sibling).
+
+```python
+def test_X_constants_in_lockstep_across_render_paths() -> None:
+    from server import _X_CONSTANT_A, _X_CONSTANT_B
+    from openai_app.response_formatter import (
+        _OPENAI_X_CONSTANT_A, _OPENAI_X_CONSTANT_B,
+    )
+    assert _X_CONSTANT_A == _OPENAI_X_CONSTANT_A
+    assert _X_CONSTANT_B == _OPENAI_X_CONSTANT_B
+```
+
+## Server.py change patterns
+
+A 50k+ LOC `server.py` has **three** distinct change patterns. Use the right one for the situation:
+
+| Pattern | When | How |
+|---|---|---|
+| **New connector scaffolding** | Adding a fresh connector | Delegate to a subagent with explicit file paths and conventions; review the diff carefully |
+| **Few cross-cutting sites with reasoning** | Changes that touch 2-5 sites, each requiring understanding of context | Surgical hand-patches. Never delegate — subagent iteration cap kicks in before they finish reasoning across all sites |
+| **15+ mechanical mirror-edits** | E.g. `dict[k]=v` → `store.put(k,v)` across every connector | One-shot regex transformer, stage to `.staged`, diff-review, mv |
+
+The regex-transformer-then-stage pattern is the highest-leverage of the three. Cost ~5 minutes to write the transformer, cost ~30 seconds to review the diff, ships 15+ sites with zero hand-edits and zero risk of "I missed one." The trap: comments that look like code can match too — always preview the diff before applying.
+
+## Local lint discipline (matters more than you'd think)
+
+If your CI runs `black --target-version py311` and `flake8 --jobs=1`, the local equivalents matter:
+
+```bash
+# MUST match CI's target version — local Python 3.14 black formats differently
+.venv/bin/python -m black --target-version py311 <file>
+
+# MUST run with --jobs=1 on files like server.py (Python 3.14 has a recursion issue
+# with the default parallel flake8 on 50k+ LOC files)
+.venv/bin/python -m flake8 --jobs=1 <file>
+```
+
+If CI's Black step fails, CI's Flake8 step skips — so a `# noqa` you added and a Black mismatch you missed can both bite at once and you'll only see the Black failure.
+
+## Branch protection + deploy discipline
+
+If you have branch protection requiring PRs to both your Development and main branches:
+
+- Push to `Development` → CI fires dev deploy to dev hostname
+- Push to `main` → CI fires prod deploy to prod hostname (most workflows watch only main)
+- Use the §12 release-promotion pattern from [consultant-connector-audit](../consultant-connector-audit/#12-release-promotion-prs-must-cut-from-origin-not-local) for Dev → main promotions — cut from `origin/Development`, never from local Development
+- After deploy, verify the deployed image's bytes match what you intended to ship (`git show <deploy_sha>:<file>` vs `git show HEAD:<file>`) — the image-SHA-to-bytes check catches both the stale-local trap AND the rarer case where the deploy step itself shipped a stale build artifact
+
+## Marketing site is a separate repo (verification trap)
+
+If your marketing site (homepage, connector list, docs) lives in a separate repo from your MCP server, MCP ship cycles do NOT update the marketing site. After merging an MCP change that touches a customer-visible surface (new connector, renamed tool, new endpoint), verify the marketing site directly:
+
+```bash
+curl -s https://www.<your-domain>/<page> | grep <new-thing>
+```
+
+Symptom of failing this: a customer reads the marketing site, sees the old surface, tries the new one, hits "connector not found." You shipped the MCP change but the marketing site is wrong.
+
+## Reference material
+
+The substantive pitfalls from the source skill — each one earned the hard way — covered as separate sections in this Hermes Hub:
+
+- [consultant-connector-audit](../consultant-connector-audit/) — the audit checklist that catches what this skill describes how to prevent
+- [api-development](../api-development/) — Cloud Run + database backend patterns when your MCP server has a sibling FastAPI surface
+- [scheduled-jobs](../scheduled-jobs/) — cron operating manual for the agent that operates the MCP server
+
+## When to load this skill
+
+- About to add a new connector
+- About to refactor server.py
+- A consultant submitted a connector PR and you're about to merge
+- Hit a "feature works in dev but missing in prod" symptom
+- About to do a Dev → main promotion
+- Customer reports a tool returns the wrong shape — but your tests are green
+
+If you're just running existing tools, you don't need this skill loaded.

--- a/hermes/skills/engineering/metric-spec-registry/index.md
+++ b/hermes/skills/engineering/metric-spec-registry/index.md
@@ -1,0 +1,136 @@
+---
+title: metric-spec-registry
+description: Pattern for a canonical-layer metric subsystem — store KPI definitions, not data; resolve live; surface drift between sources; never cache; provenance every answer.
+---
+
+# Metric Spec Registry
+
+When two systems in your stack compute "the same number" differently — Stripe says MRR is $X, QuickBooks recurring revenue says $Y, your dashboard widget says $Z — the question stops being "what's our MRR?" and becomes "which of these three is right, and why don't they match?"
+
+This skill describes the substrate pattern that answers both questions: a **metric spec registry** that stores user-declared KPI definitions (the expression, the source calls, the variables) and a **resolver** that evaluates them live every time, never cached. Plus a **drift report** that walks every spec with a cross-source check, fires both sides, and surfaces only the ones that disagree past tolerance.
+
+## When to load this skill
+
+- You have a multi-source environment (Stripe + QBO + dashboards, Salesforce + HubSpot + sheets, etc.) where the same business question can be answered different ways
+- You've been bitten by a "exec asked for ARR, three people gave three answers" incident
+- You're about to build a "canonical KPI" layer and want a pattern that's been beaten on
+- You want drift detection between source systems as a feature, not an end-of-quarter spreadsheet exercise
+
+## The waterfall
+
+Three layers, evaluated in order when a user asks "what's our <metric>?":
+
+1. **Truth source** (highest authority) — a user-maintained workbook or document the user explicitly declared as the source for this metric. If a TruthSource entry exists AND the spec doesn't have `prefer_truth_source: false`, use the truth source's number
+2. **Metric spec** — a declared expression in a mini-DSL that compiles to vendor API calls. Resolved live, never cached. Carries `cross_source_checks` for drift detection
+3. **Raw connector data** (lowest authority) — only when no spec exists and the user didn't register a truth source. Labeled "estimate" in the response, not asserted as canonical
+
+The waterfall is the discipline that makes the system trustworthy. Without it, every AI client computes the metric its own way and the user gets three different answers from three different chat windows.
+
+## The data model
+
+A `MetricSpec` is a frozen dataclass with these fields:
+
+| Field | Purpose |
+|---|---|
+| `key` | Short stable identifier (`mrr`, `aov`, `monthly_active_customers`) |
+| `label` | Human-readable name |
+| `description` | The user's own definition — surfaced in the provenance footer |
+| `expression` | The computation in the mini-DSL. Example: `stripe.list_subscriptions(status="active").aggregate(sum, field=plan.amount)` |
+| `expected_unit` | Free-form: `USD`, `count`, `ratio`, `percent`, `days`. Renderer uses for formatting |
+| `expected_freshness` | Free text the user accepts as staleness budget: `realtime`, `daily`, `monthly`. Metadata only — does NOT trigger caching |
+| `cross_source_checks` | Other metric spec keys whose result should match this one within `tolerance_percent`. Populates the drift block on resolve |
+| `tolerance_percent` | Absolute percentage tolerance for cross_source_checks. Default 1.0. 0.0 for exact |
+| `variables` | Per-spec substitution table for `$user.<var>` references inside the expression |
+| `prefer_truth_source` | If true, the v0.1 resolver uses the truth source instead of executing the expression |
+| `version` | Bumped on every save (the pending-write commit creates a new version) |
+| `owner_email` | Who is responsible for this definition (so reviewers know who to ping) |
+
+## The resolve contract — never cached, always live, always provenance
+
+When the user asks "what's our MRR?":
+
+1. Look up the spec by key
+2. Parse the expression DSL
+3. For each source call in the expression, dispatch the matching connector tool
+4. Aggregate per the expression
+5. Evaluate `cross_source_checks` — fire each comparison spec, compare to the primary result, flag drift if outside tolerance
+6. Return:
+   - `value` — the canonical number
+   - `unit` — `USD` / `count` / etc.
+   - `provenance_footer` — a one-line human-readable summary (spec version, source calls, drift status, warnings) you MUST surface verbatim at the end of your answer
+   - `drift` — populated when cross_source_checks disagree past tolerance; carries both values and a `hypothesis` field
+   - `validation_warnings` — any parse failures, missing cross-checks, non-numeric diffs, you MUST surface inline
+
+The user should be able to see, in every answer, exactly which spec version produced the number and which source calls were dispatched. **No caching, ever** — a stale number is worse than a slow one.
+
+## Drift as a feature
+
+`metric_spec_drift_report` walks every spec with a non-empty `cross_source_checks`, resolves each one and its comparison, and returns ONLY the specs where the two values disagree beyond `tolerance_percent`. The "what's silently disagreeing in my numbers" dashboard.
+
+An empty list is the green signal — everything is within tolerance. Not an error.
+
+When drift IS reported, the response surfaces both values, the comparison spec, and the `hypothesis` field if present. Drift is not a bug; it's a signal that the truth-source story has degraded and someone needs to look. Hiding it (returning one number when two systems disagree) is the failure mode.
+
+## The mini-DSL grammar
+
+The expression syntax is the core surface. Minimum viable shape:
+
+```
+<source>.<method>(<args>).aggregate(<op>, field=<field>)
+```
+
+Example:
+
+```
+stripe.list_subscriptions(status="active").aggregate(sum, field=plan.amount)
+```
+
+The DSL parses to a typed AST. The resolver compiles each `<source>.<method>(<args>)` to a real MCP connector tool call (`stripe.list_subscriptions` → the `list_subscriptions` tool on the stripe connector). The aggregate operation runs in the resolver.
+
+Soft eval gate: a spec whose expression fails to parse is still saved, but the resolver emits `validation_warnings` every time it tries to resolve. The warnings show in the user's answer. Don't reject at write time — the user might be drafting an expression they'll fix later, and rejecting forces them to throw away the description text they wrote. Soft gate at read time is the right discipline.
+
+## Pending-write semantics (constitutional)
+
+Saves do NOT happen immediately. `metric_spec_set` returns a `pending_write_id`. The user must explicitly confirm (`canonical_pending_commit`) before the spec lands. Never silently save inferred or guessed specs.
+
+Same for delete (`metric_spec_remove`). Pending-write IDs are session-scoped and expire if unconfirmed.
+
+This is the never-silently-modify-canonical rule. The metric spec is a canonical-layer entity; modifying it without explicit user consent breaks the trust contract the registry's existence depends on.
+
+## Connector dispatch boundary
+
+In a v0 implementation, the resolver supports a small fixed set of connectors (Stripe + Shopify is a sensible starting pair — recurring revenue + ecommerce revenue are the two sources users want to compare against each other for MRR/AOV).
+
+Expanding the supported set is straightforward but each new connector needs:
+
+- A DSL grammar entry mapping `<source>.<method>` → the underlying tool call
+- A schema/coercion layer so the aggregate operations get typed inputs (numbers are numbers, not strings)
+- A test fixture asserting the resolver returns the right number for a known input
+
+Resist the temptation to expand the set in the same PR that ships the registry. The substrate is the lift; the connector additions are increments.
+
+## Lockstep test — protect the renderer
+
+The provenance footer is rendered by your response formatter. If your MCP server has dual render paths (one for raw HTTP, one for ChatGPT mega-tool), the footer string lives in both. See [mcp-architecture](../mcp-architecture/#dual-render-path-trap-serverpy-vs-chatgpt-app) for the dual-render-path pattern and the lockstep equality test.
+
+Without a lockstep test, the next refactor will rendering-drift the provenance footer between paths, and customers will see different "powered by spec v3" footers on different clients. Tiny user-visible bug, hard to diagnose.
+
+## When this pattern fits
+
+You want the metric spec registry when:
+
+- Multiple source systems can answer the same question
+- "Which one is right" is a real business risk (board meetings, customer-facing pricing, financial close)
+- Users would rather see "Stripe says X, QBO says Y, they disagree by 2%, here's the hypothesis" than a confidently-wrong single number
+- You're already operating an MCP / multi-connector substrate where the source calls are addressable
+
+You don't want it when:
+
+- Single source of truth exists and is trusted (just use that source)
+- The metric is purely operational (memory usage, cron status) — those don't need canonical resolution
+- The user prefers fast/cached numbers over right ones (rare in B2B finance, common in operational dashboards)
+
+## Related
+
+- [consultant-connector-audit §9.6](../consultant-connector-audit/#96-parallel-code-path-trap-refactor-missed-sibling) — the dual-render-path trap the registry's renderer is vulnerable to
+- [mcp-architecture](../mcp-architecture/) — the substrate the registry assumes you have

--- a/hermes/skills/engineering/scheduled-jobs/index.md
+++ b/hermes/skills/engineering/scheduled-jobs/index.md
@@ -1,0 +1,102 @@
+---
+title: scheduled-jobs
+description: Operate, debug, and verify recurring agent work — daily audits, inbox monitors, watchdogs, no-agent scripts. Covers the profile vs default-profile split, server-local time semantics, and the discipline that keeps cron from rotting silently.
+---
+
+# Scheduled Jobs (Hermes Cron)
+
+Operate and debug a Hermes agent's recurring work — the daily audit email, support-inbox monitor, agent-to-agent watchdogs, vendor sync jobs, end-of-day digests. All of it runs on Hermes cron and the rules here apply to every job in that family.
+
+## Canonical tooling — use it, don't hand-edit jobs.json
+
+Profile-local cron management belongs to two scripts:
+
+| Tool | Purpose |
+|---|---|
+| `scripts/cron_job_manager.py` | add / list / show / enable / disable / remove / validate. Auto-backups `jobs.json` before every write. Refuses duplicate names, duplicate (script, profile) pairs, and jobs whose scripts don't exist at the resolved path. |
+| `scripts/cron_health_watchdog.py` (a recurring job in itself) | Scans profile jobs only. Alerts to your team's status channel via Telegram or Slack with 24h dedup on sustained outages. Silent unless something needs attention. Exits 0 on its own internal failures (no flaky-watchdog noise). |
+
+**Rule:** NEVER write directly to `~/.hermes/cron/jobs.json` or the profile equivalent. Hand-edits lose the auto-backup, bypass the duplicate-name guard, and silently break the in-memory state of the running cron daemon.
+
+## Server-local time, not UTC
+
+This is the single biggest source of confusion in cron scheduling. Hermes cron evaluates schedule expressions in **server-local time**, not UTC. If your dev box is in Arizona (GMT-7 year-round, no DST) and you write `0 13 * * *` expecting 1 PM UTC, the job will fire at 1 PM Arizona time (which is 20:00 UTC).
+
+Confirm via `next_run_at` in the job's status output — it shows the resolved next-fire-time in UTC, so you can compare against your intent.
+
+For a job that should fire at 9 AM Arizona / 16:00 UTC, write `0 9 * * *` and confirm `next_run_at` resolves to 16:00 UTC on the next day matching the day-of-week constraint.
+
+## The profile vs default-profile split
+
+If your Hermes installation has multiple profiles (e.g. `default` + a named profile per workstream), each profile has its OWN `jobs.json` and its OWN cron daemon. Confusing them is a common failure mode:
+
+- The default profile's cron: `~/.hermes/cron/jobs.json`, managed by `hermes -p default gateway`
+- A named profile's cron: `~/.hermes/profiles/<name>/cron/jobs.json`, managed by `hermes -p <name> gateway`
+
+**Important:** if you only see one of the two gateways running and you reinstall, you may orphan jobs from the other. Two gateways is the normal state. Verify both are running before assuming a job is dead.
+
+## The "no_agent" cron pattern
+
+Some jobs don't need an LLM at all — they're just scripts that produce a notification when they detect something. Examples:
+
+- Watchdog: memory > 90%, send Telegram alert
+- API poller: fetch a status endpoint, alert if degraded
+- Build monitor: check CI, post to Slack on failure
+
+For these, set `no_agent: true` in the job definition. The cron daemon will execute the script directly without spinning up an agent loop:
+
+- Stdout from the script becomes the message body
+- **Empty stdout = silent** (the watchdog pattern — only notify when there's something to notify about)
+- Non-zero exit code triggers an error alert (so a broken watchdog can't fail silently)
+
+When to use `no_agent: true`:
+- Recurring script-only pings where the script itself produces the exact message text
+- Memory/disk/GPU watchdogs, threshold alerts, heartbeats
+- CI notifications, API pollers with a fixed output shape
+
+When to use the default (LLM-driven):
+- Anything that needs reasoning — summarize a feed, draft a daily briefing, pick interesting items, rephrase data for a human
+- Conditional logic based on content
+
+## In-prompt curl is a trap (use a script instead)
+
+When you're writing a job's prompt and you want it to send a Telegram or Slack message, the natural instinct is to embed a `curl` invocation in the prompt body. **Don't.** Hermes' tool-approval layer may block the in-prompt curl, AND the ticker UX (the "agent is working..." indicator) gets killed when an unapproved tool fires.
+
+Pattern: write a small script (`scripts/post_to_<channel>.sh`) that takes a message as `$1` and handles the curl. Reference the script from the prompt. The script runs through normal `terminal()` invocation, no approval gate, no ticker disruption.
+
+## Reinstalling the gateway
+
+If you ever need to fully reinstall the Hermes cron gateway (e.g. after a system update broke something):
+
+```bash
+# Will prompt twice for confirmation
+printf "Y\nY\n" | sudo hermes -p default gateway install --system
+```
+
+For a named profile, replace `default` with the profile name. Verify both gateways are still running afterwards.
+
+## Status discipline
+
+Every job should write its last result to a status file (`scripts/<job>_status.json` or similar) AND log to your standard log path. The cron daemon tracks `last_status` per job, but that's a coarse "ok / error" — the status file is where the operator looks when they need to diagnose "why did this job report ok but the email never arrived?"
+
+Pattern: structure the status file as `{"timestamp": ..., "summary": ..., "details": {...}}`. The watchdog skill (above) reads these files and surfaces anomalies before they compound.
+
+## Drift detection
+
+A recurring problem with crontabs: jobs that USED to work but silently degraded — the API they call moved endpoints, the script's dependencies got upgraded, the auth token expired. The watchdog catches the loudest failures, but the subtle ones (job runs, exits 0, produces wrong output) need active drift detection.
+
+For any job whose output has a known shape, write a tiny assertion at the end of the script:
+
+```python
+result = do_the_work()
+assert isinstance(result, dict)
+assert "summary" in result
+assert len(result["items"]) > 0  # if you expect items every run
+```
+
+A failing assertion exits non-zero, the cron watchdog surfaces it, you get a real signal.
+
+## Related
+
+- [api-development](../api-development/) — when your cron job hits a Cloud Run API, the deploy-verification patterns apply
+- [honcho-memory-usage](../honcho-memory-usage/) — for cron jobs that need cross-session memory

--- a/hermes/skills/index.md
+++ b/hermes/skills/index.md
@@ -17,9 +17,10 @@ Skills are reusable agent capabilities — step-by-step workflows with tools, tr
 | [Marketplace](/hermes/skills/marketplace/) | 85 curated skills from skills.sh with install counts |
 | [Marketing](/hermes/skills/marketing/) | 45 SEO, CRO, ads, content, growth skills |
 | [Development](/hermes/skills/development/) | GitHub, code review, issues, CI/CD skills |
+| [Engineering](/hermes/skills/engineering/) | Platform construction: MCP server, connector audit, multi-repo coordination |
 | [Operations](/hermes/skills/operations/) | Email, cron, audit, lead capture, video skills |
 
-## CorpusIQ Native Skills (73)
+## CorpusIQ Native Skills (80)
 
 Built and maintained for the CorpusIQ Hermes deployment. Load automatically when the agent profile matches.
 


### PR DESCRIPTION
# Add Engineering skills section to Hermes Hub — 7 platform-construction skills

Adds a new `engineering/` section to the skills tree, distinct from the existing `development/` section.

**The distinction:**
- `development/` covers tools every dev uses (GitHub PRs, code review, repo cloning, syntax checks) — generic, well-trodden
- `engineering/` covers the patterns that emerge when you operate a customer-facing platform at the size where silent failures compound, consultant-authored connectors need audit before merge, two systems drift over "the same number," and release-promotion discipline turns into the difference between "shipped" and "actually changed prod"

## What ships

7 new skill pages under `hermes/skills/engineering/`:

| Skill | Purpose |
|---|---|
| [`consultant-connector-audit`](https://github.com/CorpusIQ/corpusiq-docs/blob/docs/hermes-engineering-section/hermes/skills/engineering/consultant-connector-audit/index.md) | 13-section audit pass before shipping non-core-authored connector code. The single highest-leverage skill in the set — born from a real 9-PR Mailchimp churn cycle. Catches the bug clusters before customers see them |
| [`mcp-architecture`](https://github.com/CorpusIQ/corpusiq-docs/blob/docs/hermes-engineering-section/hermes/skills/engineering/mcp-architecture/index.md) | Field guide for a 50k+ LOC MCP server: file map, per-connector triplet, dual-render-path trap, bulk-regex migration recipe |
| [`metric-spec-registry`](https://github.com/CorpusIQ/corpusiq-docs/blob/docs/hermes-engineering-section/hermes/skills/engineering/metric-spec-registry/index.md) | Canonical-layer metric subsystem — declared KPI definitions, live resolution, drift detection between sources, never cached |
| [`api-development`](https://github.com/CorpusIQ/corpusiq-docs/blob/docs/hermes-engineering-section/hermes/skills/engineering/api-development/index.md) | Cloud Run + FastAPI patterns: test-fixture traps (JSONB compile hook ordering, UUID type matching, JWT key bootstrap), self-destructing admin migrations, JWT JWKS contract |
| [`frontend-development`](https://github.com/CorpusIQ/corpusiq-docs/blob/docs/hermes-engineering-section/hermes/skills/engineering/frontend-development/index.md) | Next.js + Vercel patterns for marketing + dashboard in one repo: canonical-constant rule, deploy verification, cross-repo boundary |
| [`scheduled-jobs`](https://github.com/CorpusIQ/corpusiq-docs/blob/docs/hermes-engineering-section/hermes/skills/engineering/scheduled-jobs/index.md) | Hermes cron operating manual: server-local time, profile vs default-profile split, no-agent watchdog pattern, in-prompt-curl trap |
| [`honcho-memory-usage`](https://github.com/CorpusIQ/corpusiq-docs/blob/docs/hermes-engineering-section/hermes/skills/engineering/honcho-memory-usage/index.md) | Server-side semantic memory via Honcho MCP — when it complements MEMORY.md/USER.md, when to read vs write, cost discipline |

## Voice and provenance

Each page preserves the source skill's voice (specific, slightly irreverent, war-story-based) but strips identifying refs — PR numbers, customer names, vendor IDs, internal paths — so the patterns are generalizable to anyone running a similar substrate.

The Mailchimp 9-PR cycle gets named once in the consultant-connector-audit as "a real incident on the team's connector substrate" because that specific war story is the spine of the skill — without it the skill is generic and forgettable. The other references (Stripe Phase 1 orphaned routes, Facebook scope drift, MSR dual-render-path) are kept anonymous.

## Modified files

- `hermes/index.md` — updated catalog count description
- `hermes/skills/index.md` — added Engineering row to quick-links table
- `hermes/skills/catalog/index.md` — added Engineering category with 7-skill table, updated native subtotal 73 → 80, updated total 290 → 297

## Why ship this

The team's engineering agent (this account) has accumulated ~12 platform-engineering skills over the last few weeks of operating the multi-connector MCP substrate, the FastAPI backend, the frontend, and the cron infrastructure. The Hub's `development/` section was 29 lines of bullet points; there was no home for "the pattern that prevents the 9-PR churn cycle" — yet that pattern is the thing that actually keeps customer-facing platforms from rotting.

These 7 pages are the curated tier — the ones I'd hand to a new platform engineer joining the team. If the section gets uptake, the next batch can add the deeper reference pages (parallel-path lockstep pattern, daily matrix audit script, JWT smoke recipe, dual-render-path catalog) and the second tier of skills (`corpusiq-branded-email`, `corpusiq-team-hermes-instances`, internal data reads).

## Open questions for review

1. **Section name.** Engineering vs Platform Engineering vs Platform Construction — any preference?
2. **Catalog count policy.** The catalog says "290 total: 73 native + 217 marketplace" — I updated to 297/80. There are still references to "133+ skills" elsewhere (README, hermes/README, hermes/mcp); those are pre-existing inconsistencies I didn't touch. Want me to reconcile in a follow-up?
3. **Skill SKILL.md installability.** These are docs pages, not installable SKILL.md bundles. If you want them installable via `npx skills add`, that's a separate lift — would need a GitHub repo with SKILL.md + frontmatter per skill, then a manifest. Happy to do that as phase 2 if there's appetite.
4. **Inbound exchange.** I'd benefit from loading 9 of Marin's native skills into my profile (`corpusiq-email-send-checklist`, `corpusiq-fundamentals`, `corpusiq-guardrails`, `corpusiq-mcp-oauth-auth`, etc.). The catalog has descriptions but not bodies. Can you share the SKILL.md content for those, or grant me read access to her profile skills directory?
