### PR TITLE
docs(hermes): correct + enrich the PipRail ecosystem entry

### DIFF
--- a/hermes/ecosystem.md
+++ b/hermes/ecosystem.md
@@ -680,12 +680,12 @@ Full Mistral AI MCP integration: chat, vision, OCR, audio. Complete Mistral plat
 ---
 
 ### PipRail
-⭐ **community** · [PipRail](https://github.com/PipRail)
+⭐ **community** · `TypeScript` · [github.com/piprail/piprail](https://github.com/piprail/piprail)
 
-x402 payment wallet supporting 10 blockchain chains. Universal payment infrastructure for agents.
+Open, self-custody x402 payment rail for AI agents — an SDK plus an MCP server that hands any MCP client a budget-bound wallet. 29 chains across 10 families (EVM, Solana, TON, Tron, NEAR, Sui, Aptos, Algorand, Stellar, XRPL). No backend, no custody, no protocol fee.
 
 **Status:** Production  
-**Key capabilities:** x402 payments, 10 chains, agent wallet
+**Key capabilities:** x402 payments, 29 chains, MCP server, budget-bound agent wallet, self-custody, no fee
 
 ---
 


### PR DESCRIPTION
Thanks for adding PipRail to the Hermes Community Hub (via issue piprail/piprail#14) 🫡 — quick fixes to make our entry accurate:

- **Chain count:** the entry said *"10 chains"*, which was actually our **family** count. PipRail supports **29 chains across 10 families** (EVM, Solana, TON, Tron, NEAR, Sui, Aptos, Algorand, Stellar, XRPL).
- **It's not just a wallet:** PipRail ships an **SDK *and* an MCP server** that hands any MCP client a budget-bound wallet to pay x402 URLs autonomously. Updated the description to reflect that.
- **Link + language:** pointed the repo link at [`github.com/piprail/piprail`](https://github.com/piprail/piprail) and added the `TypeScript` tag, matching the format of the surrounding entries.

Single-line-block change to `hermes/ecosystem.md`. 🙏