### PR TITLE
ci(pages): MkDocs GitHub Pages build + deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,76 @@
+name: Deploy docs to GitHub Pages
+
+# Builds the MkDocs Material site and publishes it to GitHub Pages.
+# The production URL is https://www.corpusiq.io/docs/ — corpusiq-frontend
+# rewrites /docs and /docs/:path* to this Pages site
+# (https://corpusiq.github.io/corpusiq-docs/). mkdocs.yml site_url is set to
+# the proxied production path so internal asset/links resolve correctly there.
+#
+# NOTE: GitHub Pages must be enabled once (owner action) under
+# Settings -> Pages -> Build and deployment -> Source: GitHub Actions.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - 'docs/**'
+      - '**/*.md'
+      - 'assets/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+# Allow the workflow to deploy to Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Serialize Pages deploys; cancel nothing in flight so a running deploy finishes.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # awesome-pages + git-based edit_uri benefit from full history
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build site
+        # Non-strict: the docs content currently has a handful of cross-file
+        # relative links that MkDocs flags as warnings. Strict mode aborts on
+        # those, which would block every deploy. Keep builds shipping; the link
+        # warnings are tracked separately as content cleanup.
+        run: mkdocs build --site-dir ./site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# MkDocs build dependencies for the CorpusIQ Docs site.
+# Pinned to the major versions verified to build this repo's mkdocs.yml
+# (material theme + awesome-pages plugin; pymdownx ships with mkdocs-material).
+mkdocs-material>=9.5,<10
+mkdocs-awesome-pages-plugin>=2.9,<3


### PR DESCRIPTION
## What

Adds the missing piece to make `corpusiq-docs` self-publishing:

- **`.github/workflows/pages.yml`** — builds the MkDocs Material site and deploys it to GitHub Pages (`upload-pages-artifact` → `deploy-pages`). Triggers on push to `main` (docs/config changes) and manual `workflow_dispatch`.
- **`requirements.txt`** — `mkdocs-material` + `mkdocs-awesome-pages-plugin`, the two deps this repo's `mkdocs.yml` needs.

## Why

The repo already has `mkdocs.yml`, and `corpusiq-frontend` `main` already rewrites `/docs` and `/docs/:path*` → `https://corpusiq.github.io/corpusiq-docs/`. The only thing missing was the build/deploy workflow + deps so the Pages site actually exists.

## Verified

- Built the site locally against `main` content with the pinned `requirements.txt` — green, produces `index.html`, `api/`, `quick-start/`, etc.
- Build is intentionally **non-strict**: the docs content currently has a handful of cross-file relative-link warnings that `--strict` turns into hard failures, which would block every deploy. Those link fixes are content cleanup, tracked separately.

## One owner-only step before this can run

GitHub Pages must be enabled once (no API/tool for this):

**Settings → Pages → Build and deployment → Source: GitHub Actions**

After that, merging this PR (or a manual *Run workflow*) builds and publishes. Once `https://corpusiq.github.io/corpusiq-docs/` returns 200, `https://www.corpusiq.io/docs/` serves it through the existing frontend rewrite.

⚠️ **Ordering note:** the frontend `/docs` → Pages rewrite is already merged on `corpusiq-frontend` main. Until Pages is enabled and the first build succeeds, the Pages origin 404s — so enable Pages + run this **before** the next `corpusiq-frontend` production deploy, or `/docs` will proxy to a 404 in the window between.

— Hermes (CorpusIQ Dev)
