### PR TITLE
fix(hermes): quote YAML frontmatter to stop GitHub render errors (11 pages)

### DIFF
--- a/hermes/README.md
+++ b/hermes/README.md
@@ -1,6 +1,6 @@
 ---
 title: Hermes Agent Production Knowledge Repository — Deploy Autonomous AI Agents
-description: Everything the official Hermes docs don't cover. Production-tested patterns from 1,200+ hours of autonomous operations: 6-layer architecture, 133+ skills, 38 crons, 6 memory systems, 37+ MCP connectors.
+description: "Everything the official Hermes docs don't cover. Production-tested patterns from 1,200+ hours of autonomous operations: 6-layer architecture, 133+ skills, 38 crons, 6 memory systems, 37+ MCP connectors."
 category: Documentation
 tags:
   - hermes-agent

--- a/hermes/agents/index.md
+++ b/hermes/agents/index.md
@@ -1,6 +1,6 @@
 ---
 title: Hermes Agent Library — 9 Production-Ready AI Agent Blueprints
-description: Complete library of 9 role-specific Hermes agent configurations: sales, marketing, devops, support, finance, HR, research, legal, and executive. Deploy in minutes with cron schedules and MCP connectors.
+description: "Complete library of 9 role-specific Hermes agent configurations: sales, marketing, devops, support, finance, HR, research, legal, and executive. Deploy in minutes with cron schedules and MCP connectors."
 category: Agents
 tags:
   - agent-library

--- a/hermes/index.md
+++ b/hermes/index.md
@@ -1,6 +1,6 @@
 ---
 title: Hermes Agent Knowledge Repository — Production Autonomous Agent Reference
-description: Complete production reference for autonomous Hermes agents: 6-layer architecture, 133+ skills, 38 crons, 6 memory systems, and 37+ MCP business connectors. Real deployment on DGX Spark + Mac Mini M4.
+description: "Complete production reference for autonomous Hermes agents: 6-layer architecture, 133+ skills, 38 crons, 6 memory systems, and 37+ MCP business connectors. Real deployment on DGX Spark + Mac Mini M4."
 category: Documentation
 tags:
   - hermes-agent

--- a/hermes/knowledge/index.md
+++ b/hermes/knowledge/index.md
@@ -1,6 +1,6 @@
 ---
 title: Memory Architecture Guide for Hermes Agent — Triple-Stack Persistent AI Memory
-description: Hermes Agent memory architecture guide covering the triple stack: Honcho peer memory, GBrain organizational knowledge, memcore-cloud cross-session recall, GraphRAG, and Session DB. Production-tested persistent AI agent memory.
+description: "Hermes Agent memory architecture guide covering the triple stack: Honcho peer memory, GBrain organizational knowledge, memcore-cloud cross-session recall, GraphRAG, and Session DB. Production-tested persistent AI agent memory."
 category: knowledge
 tags: [hermes-agent, memory, honcho, gbrain, memcore-cloud, graphrag, persistent-memory, knowledge-management]
 last_updated: 2026-06-16

--- a/hermes/outputs/index.md
+++ b/hermes/outputs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Hermes Agent Outputs — Real-World Implementation Guides & Case Studies
-description: Field manual of Hermes Agent implementations: industry case studies, company-size guides, and copy-paste cron templates. Real automations for compliance, healthcare, finance, manufacturing, and more.
+description: "Field manual of Hermes Agent implementations: industry case studies, company-size guides, and copy-paste cron templates. Real automations for compliance, healthcare, finance, manufacturing, and more."
 category: Outputs
 tags:
   - case-studies

--- a/hermes/outputs/workflows/templates.md
+++ b/hermes/outputs/workflows/templates.md
@@ -1,6 +1,6 @@
 ---
 title: Hermes Cron Templates — 12 Copy-Paste Workflows for Autonomous Agents
-description: Ready-to-deploy cron templates for Hermes Agent: email triage, report generation, data sync, anomaly detection, SLA monitoring, and more. Copy, adapt, deploy in minutes.
+description: "Ready-to-deploy cron templates for Hermes Agent: email triage, report generation, data sync, anomaly detection, SLA monitoring, and more. Copy, adapt, deploy in minutes."
 category: Outputs
 tags:
   - cron-templates

--- a/hermes/skills/catalog/prisma/prisma-cli.md
+++ b/hermes/skills/catalog/prisma/prisma-cli.md
@@ -1,6 +1,6 @@
 ---
 name: prisma-cli
-description: Prisma CLI workflows: migrate, generate, studio. Command-line tools for database management. 9.6K installs.
+description: "Prisma CLI workflows: migrate, generate, studio. Command-line tools for database management. 9.6K installs."
 triggers:
   - "prisma cli"
 source: skills.sh marketplace

--- a/hermes/skills/catalog/supabase/supabase.md
+++ b/hermes/skills/catalog/supabase/supabase.md
@@ -1,6 +1,6 @@
 ---
 name: supabase
-description: Full Supabase platform: auth, storage, edge functions. Complete Supabase integration for AI agents. 114.1K installs.
+description: "Full Supabase platform: auth, storage, edge functions. Complete Supabase integration for AI agents. 114.1K installs."
 triggers:
   - "supabase"
 source: skills.sh marketplace

--- a/hermes/skills/marketplace/new-june11-2026-update2/index.md
+++ b/hermes/skills/marketplace/new-june11-2026-update2/index.md
@@ -1,6 +1,6 @@
 ---
-title: June 11, 2026 — Update #2 (28 New Skills)
-description: Evening sweep: 23 OpenClaw ecosystem skills from aradotso/hermes-skills plus 5 new standalone Hermes skills. Agent control centers, Chinese platform integrations, deployment tooling, PPT generation, QQ bot, and marketing dashboard.
+title: "June 11, 2026 — Update #2 (28 New Skills)"
+description: "Evening sweep: 23 OpenClaw ecosystem skills from aradotso/hermes-skills plus 5 new standalone Hermes skills. Agent control centers, Chinese platform integrations, deployment tooling, PPT generation, QQ bot, and marketing dashboard."
 ---
 
 # June 11, 2026 — Update #2: 28 New Skills

--- a/hermes/skills/marketplace/new-june12-2026-update/index.md
+++ b/hermes/skills/marketplace/new-june12-2026-update/index.md
@@ -1,6 +1,6 @@
 ---
 title: June 12, 2026 (Update) — OpenClaw Security Suite
-description: Afternoon sweep: 13-skill OpenClaw security suite discovered from useai-pro (UseClawPro). Flagship skill-vetter at 19,340 installs.
+description: "Afternoon sweep: 13-skill OpenClaw security suite discovered from useai-pro (UseClawPro). Flagship skill-vetter at 19,340 installs."
 ---
 
 # June 12, 2026 (Update) — OpenClaw Security Suite

--- a/hermes/skills/marketplace/new-june12-2026/index.md
+++ b/hermes/skills/marketplace/new-june12-2026/index.md
@@ -1,6 +1,6 @@
 ---
 title: June 12, 2026 — New Hermes Security & UI Skills
-description: Overnight sweep: 3 new Hermes-specific skills discovered — security attestation, traffic monitoring, and a Hermes-themed UI deck. From ClawSec and nexu-io.
+description: "Overnight sweep: 3 new Hermes-specific skills discovered — security attestation, traffic monitoring, and a Hermes-themed UI deck. From ClawSec and nexu-io."
 ---
 
 # June 12, 2026 — New Hermes Security & UI Skills


### PR DESCRIPTION
## What this fixes

The `hermes/` folder (and 10 other pages) showed GitHub's pink **frontmatter
parse-error banner** above the rendered README, and dropped their meta
descriptions on the mkdocs build. Screenshot of the symptom: the banner sits
right above the HERMES-AGENT logo on
[github.com/CorpusIQ/corpusiq-docs/tree/main/hermes](https://github.com/CorpusIQ/corpusiq-docs/tree/main/hermes).

## Root cause

The June 16 SEO sweep (`8e9b1dd`) injected YAML frontmatter with **unquoted
string values**. Two failure modes:

1. **Hard parse error** — a value containing `: ` (colon-space):
   > `description: ...autonomous operations: 6-layer architecture...`

   YAML reads the inner `: ` as a nested mapping key → *"mapping values are not
   allowed here"* → GitHub shows the banner, and mkdocs drops the whole
   frontmatter so the page emits **no** `<meta name="description">` at all.

2. **Silent truncation** — a value containing ` #`:
   > `title: June 11, 2026 — Update #2 (28 New Skills)`

   YAML reads ` #2...` as a comment → the title silently becomes
   *"June 11, 2026 — Update"*.

So this wasn't just cosmetic: those 11 pages were the ones **losing the exact
meta-description coverage** from the SEO audit. Fixing them recovers it.

## The fix

Double-quote the affected `title` / `description` / `name` values. **Content is
unchanged — quote-wrap only.** Values that already parsed cleanly (bare dates
like `last_updated`, already-quoted strings) are left alone, so the diff is
exactly the 11 broken files (12 insertions / 12 deletions).

## Verification

- ✅ All 200 `hermes/` frontmatter blocks now parse cleanly (0 remaining broken)
- ✅ No broken frontmatter anywhere else in the repo
- ✅ Full `mkdocs build` (non-strict, matching `pages.yml`) exits 0 — only the
  pre-existing cross-link INFO warnings remain
- ✅ Rendered HTML now carries the complete meta description on the
  formerly-broken pages, and the `#2` title renders intact

## Note for the record

The `8e9b1dd` sweep that introduced this was mine (authored as *Hermes (CorpusIQ
Agent)*), so this is me cleaning up after myself — not anything you or Marin did.

## Open question

Want a tiny **frontmatter lint** added to `pages.yml` so this class of bug fails
the build instead of rendering a banner? It's ~15 lines (a `yaml.safe_load` loop
over `hermes/**/*.md`). Happy to add it in a follow-up if you want the guardrail;
left it out here to keep this PR to the surgical fix.
