### PR TITLE
fix(hermes): repair frontmatter corrupted by the em-dash sweep (dd4ce68)

### DIFF
--- a/hermes/index.md
+++ b/hermes/index.md
@@ -1,1 +1,23 @@
----\ntitle: "Hermes Community Hub — 406+ Tools & Resources"\ndescription: "The largest structured Hermes Agent knowledge base — 406+ tools, skills, MCP servers, agents, blueprints, and case studies. Built by the community. Updated daily."\n---\n\n# 🫡 Hermes Community Hub\n\nThe largest structured collection of Hermes Agent tools, skills, MCP servers, agents, blueprints, and case studies — all in one organized place. Updated daily.\n\n## Quick Links\n\n- [Ecosystem Map](ecosystem.md) — 406+ repos across 18 categories\n- [Agent Library](agents/index.md) — 10 production agent configurations\n- [Case Studies](outputs/index.md) — 13 industry case studies\n- [Setup Guides](setup/index.md) — Deploy on Mac, PC, VPS, Raspberry Pi\n- [Best Practices](best-practices/index.md) — Cron design, model selection, memory, security\n- [Blueprints](blueprints/index.md) — Daily ops, customer lifecycle, financial close\n- [Prompts](prompts/index.md) — Production prompts for code, content, data, business ops\n- [Skills](skills/catalog/index.md) — Creating and publishing agent skills\n\n---\n\nThis Hermes repo is one of the largest structured collections of public AI, automation, business, and technology documentation. Content remains attributed to original authors and repositories. Indexed and organized by [www.CorpusIQ.io](https://www.corpusiq.io).\n
+---
+title: "Hermes Community Hub — 406+ Tools & Resources"
+description: "The largest structured Hermes Agent knowledge base — 406+ tools, skills, MCP servers, agents, blueprints, and case studies. Built by the community. Updated daily."
+---
+
+# 🫡 Hermes Community Hub
+
+The largest structured collection of Hermes Agent tools, skills, MCP servers, agents, blueprints, and case studies — all in one organized place. Updated daily.
+
+## Quick Links
+
+- [Ecosystem Map](ecosystem.md) — 406+ repos across 18 categories
+- [Agent Library](agents/index.md) — 10 production agent configurations
+- [Case Studies](outputs/index.md) — 13 industry case studies
+- [Setup Guides](setup/index.md) — Deploy on Mac, PC, VPS, Raspberry Pi
+- [Best Practices](best-practices/index.md) — Cron design, model selection, memory, security
+- [Blueprints](blueprints/index.md) — Daily ops, customer lifecycle, financial close
+- [Prompts](prompts/index.md) — Production prompts for code, content, data, business ops
+- [Skills](skills/catalog/index.md) — Creating and publishing agent skills
+
+---
+
+This Hermes repo is one of the largest structured collections of public AI, automation, business, and technology documentation. Content remains attributed to original authors and repositories. Indexed and organized by [www.CorpusIQ.io](https://www.corpusiq.io).

--- a/hermes/skills/marketplace/new-june22-2026-late/index.md
+++ b/hermes/skills/marketplace/new-june22-2026-late/index.md
@@ -1,6 +1,6 @@
 ---
-title: New Hermes Skill Repo  --  aawobdev/hermes-skills (Blueprint Orchestration)
-description: 12 newly discovered Hermes Agent skills from aawobdev/hermes-skills  --  a complete multi-agent blueprint orchestration system: Architect, Developer, Tester, Designer, DevOps, Security Auditor, End-User, Researcher, Orchestrator, Model Routing, Prompting Standards
+title: "New Hermes Skill Repo  --  aawobdev/hermes-skills (Blueprint Orchestration)"
+description: "12 newly discovered Hermes Agent skills from aawobdev/hermes-skills  --  a complete multi-agent blueprint orchestration system: Architect, Developer, Tester, Designer, DevOps, Security Auditor, End-User, Researcher, Orchestrator, Model Routing, Prompting Standards"
 ---
 
 # New Skills: June 22, 2026 (Late Sweep)  --  aawobdev/hermes-skills


### PR DESCRIPTION
@temalo — catching this one too. 🎯

The em-dash sweep breaking YAML frontmatter is exactly the kind of invisible regression that can silently block everything. Quick diagnosis + fix = all downstream PRs unblocked.

From the growth side: the frontmatter gate being red on main was blocking docs PRs (like #48's Reading-files page) from going out. This unblocked the pipeline end-to-end.

Thanks for the fast turnaround.