### PR TITLE
ci(docs): run frontmatter gate on every push/PR (drop paths filter)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,26 +1,28 @@
 name: Validate docs
 
-# Fast pre-merge gate. Runs on pull requests (and direct pushes to main) that
-# touch Markdown or the validator itself. Catches broken YAML frontmatter BEFORE
-# it reaches the non-strict mkdocs build — where it would otherwise render a pink
+# Fast pre-merge gate. Runs on EVERY pull request and EVERY push to main —
+# deliberately WITHOUT a `paths:` filter. Catches broken YAML frontmatter BEFORE
+# it reaches the non-strict mkdocs build, where it would otherwise render a pink
 # parse banner on GitHub and silently drop <meta name="description"> tags.
 #
+# Why no `paths:` filter (hardened 2026-06-26): a path-filtered gate gives a
+# false sense of safety. A direct push to main carrying broken frontmatter
+# (e.g. the dd4ce68 em-dash sweep that flattened hermes/index.md and broke a
+# skills page) slipped through and turned main red with NO Validate-docs run
+# recorded for that push. The marketplace/SEO sweeps push straight to main and
+# touch hundreds of .md files at once, so the cost of running this ~12-second
+# check unconditionally is trivial next to the cost of a silent break that
+# blocks every subsequent docs PR. Run it on everything; never gate it behind a
+# path glob that can fail to match or fail to evaluate on a given push.
+#
 # This is deliberately separate from pages.yml (the deploy workflow): it gives
-# PRs a quick green/red check without doing a full site build, and it runs on the
-# direct-push vector too (the marketplace sweeps push straight to main).
+# PRs a quick green/red check without doing a full site build, and it runs on
+# the direct-push-to-main vector too.
 
 on:
   pull_request:
-    paths:
-      - '**/*.md'
-      - 'scripts/validate_frontmatter.py'
-      - '.github/workflows/validate.yml'
   push:
     branches: [main]
-    paths:
-      - '**/*.md'
-      - 'scripts/validate_frontmatter.py'
-      - '.github/workflows/validate.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What
Removes the `paths:` filter from the `Validate docs` (frontmatter) workflow so it runs on **every** PR and **every** push to main, unconditionally.

## Why — corrected root cause
My earlier diagnosis (relayed to Ted + Ben) said the gate "only runs when the validator file itself changes." That was **wrong** — the workflow already listed `**/*.md` under both `pull_request` and `push`. The real, evidence-backed finding:

- `dd4ce68` (the em-dash sweep) was a **direct push to main** touching 358 `.md` files on 2026-06-22.
- The `validate.yml` gate **already existed** at that point (added 2026-06-17, PR #39) and its `paths` filter matched.
- Yet the run history shows **zero `Validate docs` runs for that push** — the gate's first-ever push-to-main runs are both today (6/26). So a path-filtered `push` trigger silently failed to fire on the exact bulk direct-push it was meant to catch.

Rather than keep debugging *why* the path filter didn't evaluate on that push (GitHub's path-filter behavior on bulk/direct pushes is the suspect), the robust fix is to stop gating a ~12-second check behind a path glob at all. The marketplace/SEO sweeps push straight to main in bulk; the check is cheap and the blast radius of skipping it is "every docs PR blocked." Run it on everything.

## Change
```diff
 on:
-  pull_request:
-    paths:
-      - '**/*.md'
-      - 'scripts/validate_frontmatter.py'
-      - '.github/workflows/validate.yml'
-  push:
-    branches: [main]
-    paths:
-      - '**/*.md'
-      - 'scripts/validate_frontmatter.py'
-      - '.github/workflows/validate.yml'
+  pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
```

## Verify
- Workflow YAML parses; triggers = pull_request (all), push→main (all), workflow_dispatch. No `paths` filter on either.
- This PR itself touches NO `.md` file — under the OLD filter the gate would NOT have run on it; under the new config it runs. That's the regression test: if `Validate docs` shows green on this PR, the fix works (the old config would have skipped it).