### PR TITLE
fix(docs): repair orphaned title lines in 10 SEO pages (unblocks frontmatter gate)

### DIFF
--- a/docs/chatgpt-for-quickbooks.md
+++ b/docs/chatgpt-for-quickbooks.md
@@ -1,6 +1,4 @@
 ---
-title: 'ChatGPT for QuickBooks: AI-Powered Accounting & Financial Analysis | CorpusIQ'
-  exports required.
 url: /docs/chatgpt-for-quickbooks
 h1: 'ChatGPT for QuickBooks: Transform Your Accounting Workflow with AI'
 title: ChatGPT for QuickBooks  --  AI Accounting & Financial Analysis | CorpusIQ

--- a/docs/claude-for-hubspot.md
+++ b/docs/claude-for-hubspot.md
@@ -1,6 +1,4 @@
 ---
-title: 'Claude for HubSpot: Advanced CRM Intelligence & Pipeline Analysis | CorpusIQ'
-  optimization.
 url: /docs/claude-for-hubspot
 h1: 'Claude for HubSpot: Deep CRM Intelligence with Anthropic''s AI'
 title: Claude for HubSpot  --  Advanced CRM Intelligence & Sales Analytics | CorpusIQ

--- a/docs/claude-for-shopify.md
+++ b/docs/claude-for-shopify.md
@@ -1,6 +1,4 @@
 ---
-title: 'Claude for Shopify: Advanced Ecommerce AI Analysis | CorpusIQ'
-  and inventory optimization.
 url: /docs/claude-for-shopify
 h1: 'Claude for Shopify: Deep Ecommerce Intelligence with Anthropic''s AI'
 title: Claude for Shopify  --  Advanced Ecommerce AI Analysis | CorpusIQ

--- a/docs/how-to-analyze-quickbooks-with-ai.md
+++ b/docs/how-to-analyze-quickbooks-with-ai.md
@@ -1,6 +1,4 @@
 ---
-title: 'How to Analyze QuickBooks Data with AI: Complete Guide | CorpusIQ'
-  and Claude.
 url: /docs/how-to-analyze-quickbooks-with-ai
 h1: 'How to Analyze QuickBooks Data with AI: A Complete Step-by-Step Guide'
 title: How to Analyze QuickBooks Data with AI  --  Complete Guide | CorpusIQ

--- a/docs/hubspot-ai-reporting.md
+++ b/docs/hubspot-ai-reporting.md
@@ -1,6 +1,4 @@
 ---
-title: 'HubSpot AI Reporting: Automated CRM Reports & Sales Analytics | CorpusIQ'
-  CorpusIQ MCP.
 url: /docs/hubspot-ai-reporting
 h1: 'HubSpot AI Reporting: Automated CRM Intelligence at Conversation Speed'
 title: HubSpot AI Reporting  --  Automated CRM Reports & Analytics | CorpusIQ

--- a/docs/hubspot-sales-analytics-with-ai.md
+++ b/docs/hubspot-sales-analytics-with-ai.md
@@ -1,6 +1,4 @@
 ---
-title: 'HubSpot Sales Analytics with AI: Complete Guide to Pipeline & Deal Intelligence | CorpusIQ'
-  with ChatGPT and Claude.
 url: /docs/hubspot-sales-analytics-with-ai
 h1: 'HubSpot Sales Analytics with AI: Turn Pipeline Data into Revenue Intelligence'
 title: HubSpot Sales Analytics with AI  --  Complete Guide | CorpusIQ

--- a/docs/quickbooks-ai-reporting.md
+++ b/docs/quickbooks-ai-reporting.md
@@ -1,6 +1,4 @@
 ---
-title: 'QuickBooks AI Reporting: Automated Financial Reports with AI | CorpusIQ'
-  MCP.
 url: /docs/quickbooks-ai-reporting
 h1: 'QuickBooks AI Reporting: Automated Financial Intelligence at Conversation Speed'
 title: QuickBooks AI Reporting  --  Automated Financial Reports | CorpusIQ

--- a/docs/quickbooks-business-intelligence.md
+++ b/docs/quickbooks-business-intelligence.md
@@ -1,6 +1,4 @@
 ---
-title: 'QuickBooks Business Intelligence: AI-Powered BI for Accounting | CorpusIQ'
-  data.
 url: /docs/quickbooks-business-intelligence
 h1: 'QuickBooks Business Intelligence: Turn Accounting Data into Strategic Advantage'
 title: QuickBooks Business Intelligence  --  AI-Powered BI Platform | CorpusIQ

--- a/docs/shopify-ai-analytics.md
+++ b/docs/shopify-ai-analytics.md
@@ -1,6 +1,4 @@
 ---
-title: 'Shopify AI Analytics: Automated Ecommerce Insights & Reporting | CorpusIQ'
-  required.
 url: /docs/shopify-ai-analytics
 h1: 'Shopify AI Analytics: Automated Ecommerce Intelligence at Conversation Speed'
 title: Shopify AI Analytics  --  Automated Ecommerce Insights | CorpusIQ

--- a/docs/shopify-sales-analysis-with-ai.md
+++ b/docs/shopify-sales-analysis-with-ai.md
@@ -1,6 +1,4 @@
 ---
-title: 'Shopify Sales Analysis with AI: Complete Guide to AI-Powered Sales Intelligence | CorpusIQ'
-  Claude.
 url: /docs/shopify-sales-analysis-with-ai
 h1: 'Shopify Sales Analysis with AI: Turn Raw Order Data into Revenue Intelligence'
 title: Shopify Sales Analysis with AI  --  Complete Guide | CorpusIQ


### PR DESCRIPTION
## What

Repairs broken YAML frontmatter in **10 SEO landing pages** under `docs/`, turning the repo-wide `validate_frontmatter.py` gate from red back to green.

## The corruption

A prior bulk sweep (the em-dash scrub) left each of these 10 pages with a mangled frontmatter block. Concretely:

```yaml
---
title: 'ChatGPT for QuickBooks: AI-Powered Accounting & Financial Analysis | CorpusIQ'
  exports required.          # <-- orphaned continuation, indented scalar after a complete value
url: /docs/chatgpt-for-quickbooks
h1: '...'
title: ChatGPT for QuickBooks -- AI Accounting & Financial Analysis | CorpusIQ   # the real, scrubbed title
```

The old wrapped `title:` (its head **and** a dangling continuation fragment like `  exports required.` / `  optimization.` / `  and Claude.`) survived *above* the new scrubbed `title:`. That indented fragment following an already-complete scalar is invalid YAML — `mapping values are not allowed here` at line 2 — so every one of these files failed the parser.

## Why it mattered

`scripts/validate_frontmatter.py` is a **repo-wide** gate: it scans every `.md` file and fails if *any* is broken. So these 10 pre-existing breakages were blocking **every** docs PR, not just their own — a clean new page showed a red check purely because of them.

## The fix

Drop the 2 orphaned lines (old title head + its dangling continuation) from each file, keeping the correct scrubbed `title:` and all other keys untouched.

- **Exactly 2 deletions per file, 20 total, zero body changes** (`git show --stat`: `10 files changed, 20 deletions(-)`).
- The fix was dry-run-validated before applying (each file re-parsed with `title` + `description` intact), then applied, then re-checked.

## Verification

```
$ python3 scripts/validate_frontmatter.py
frontmatter check: scanned 1096 Markdown files
✓ all frontmatter is valid   (exit 0)
```

Repo-wide green. Each fixed page keeps its correct title (e.g. `ChatGPT for QuickBooks -- AI Accounting & Financial Analysis | CorpusIQ`) and its `description` for the SEO meta tag.

## Scope

Standalone fix, deliberately **not** folded into the chat-apps docs PR (#53) — separate concern, clean diff, independently reviewable/revertable. #53's own check should go green once this merges (its content was never the cause).

Public surface — handing to Ted, not auto-merging.
