### PR TITLE
seo: shorten 239 page titles to under 60 characters

### DIFF
--- a/docs/ai-agent-users.md
+++ b/docs/ai-agent-users.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP Direct Connection  --  Connect Any AI Agent or LLM to Business Data"
+title: "MCP Direct Connection"
 description: "Connect any AI model  --  Claude, ChatGPT, Perplexity, local LLMs, or API-only models  --  to 38+ business data sources via CorpusIQ MCP. One endpoint. Works with every AI. OAuth 2.0 device flow, ~500 tools, 150+ skills."
 category: "Documentation"
 tags: ["mcp direct connection", "connect any llm to business data", "local llm business data", "mcp endpoint", "oauth device flow", "claude mcp", "chatgpt mcp", "ollama mcp", "openrouter mcp"]

--- a/docs/ai-chat-users.md
+++ b/docs/ai-chat-users.md
@@ -1,5 +1,5 @@
 ---
-title: "AI Chat Users  --  Natural Language Business Data Queries at demo.corpusiq.io"
+title: "AI Chat Users"
 description: "Access CorpusIQ AI chat at demo.corpusiq.io. Ask natural-language questions about revenue, customers, orders, and marketing across 36 connected business data sources  --  no coding required."
 category: "Documentation"
 tags: ["ai chat", "corpusiq chat", "business data chat", "natural language queries", "revenue analysis", "customer intelligence", "marketing analytics"]

--- a/docs/ai-for-audit-readiness.md
+++ b/docs/ai-for-audit-readiness.md
@@ -1,6 +1,5 @@
 ---
-title: AI for Audit Readiness  --  Continuous Audit Intelligence with CorpusIQ MCP
-title: AI for Audit Readiness | CorpusIQ MCP Platform for Audit Teams
+title: "AI for Audit Readiness"
 description: Transform audit preparation with AI. Query financial records, policies, and controls across systems in natural language. Instant evidence gathering, continuous readiness, and automated
   control testing.
 url: /docs/ai-for-audit-readiness

--- a/docs/ai-for-business-intelligence.md
+++ b/docs/ai-for-business-intelligence.md
@@ -1,6 +1,5 @@
 ---
-title: AI for Business Intelligence  --  Transform Analytics with CorpusIQ MCP
-title: AI for Business Intelligence | CorpusIQ MCP Platform for BI Transformation
+title: "AI for Business Intelligence"
 description: Discover how AI transforms business intelligence. Query data across all your tools in natural language, automate reporting, and democratize analytics with CorpusIQ's MCP platform. Real-time
   BI for every team.
 url: /docs/ai-for-business-intelligence

--- a/docs/ai-for-compliance.md
+++ b/docs/ai-for-compliance.md
@@ -1,6 +1,5 @@
 ---
-title: AI for Compliance  --  Automated Compliance Intelligence with CorpusIQ MCP
-title: AI for Compliance | CorpusIQ MCP Platform for Regulatory Intelligence
+title: "AI for Compliance"
 description: Transform compliance operations with AI. Query financial records, policies, and controls across systems in natural language. Automated compliance checks, audit trail access, and policy
   verification.
 url: /docs/ai-for-compliance

--- a/docs/ai-for-customer-support.md
+++ b/docs/ai-for-customer-support.md
@@ -1,6 +1,5 @@
 ---
-title: AI for Customer Support  --  Intelligent Support Operations with CorpusIQ MCP
-title: AI for Customer Support | CorpusIQ MCP Platform for Support Teams
+title: "AI for Customer Support"
 description: Transform customer support with AI. Query tickets, CRM, billing, and product data in natural language. Faster resolution, proactive support, and cross-source customer intelligence.
 url: /docs/ai-for-customer-support
 h1: 'AI for Customer Support: Smarter, Faster Customer Intelligence'

--- a/docs/ai-for-document-search.md
+++ b/docs/ai-for-document-search.md
@@ -1,6 +1,5 @@
 ---
-title: AI for Document Search  --  Intelligent Enterprise Search with CorpusIQ MCP
-title: AI for Document Search | CorpusIQ MCP Platform for Enterprise Search
+title: "AI for Document Search"
 description: Transform document search with AI. Find information across SharePoint, Google Drive, OneDrive, and Notion in natural language. Read document contents, not just file names. Enterprise-grade
   security.
 url: /docs/ai-for-document-search

--- a/docs/ai-for-executive-reporting.md
+++ b/docs/ai-for-executive-reporting.md
@@ -1,6 +1,5 @@
 ---
-title: AI for Executive Reporting  --  Board-Ready Intelligence with CorpusIQ MCP
-title: AI for Executive Reporting | CorpusIQ MCP Platform for Leadership
+title: "AI for Executive Reporting"
 description: Transform executive reporting with AI. Generate board-ready reports from live data across all business systems. Instant business health summaries, financial analysis, and performance metrics.
 url: /docs/ai-for-executive-reporting
 h1: 'AI for Executive Reporting: Instant Board-Ready Intelligence'

--- a/docs/ai-for-financial-analysis.md
+++ b/docs/ai-for-financial-analysis.md
@@ -1,6 +1,5 @@
 ---
-title: AI for Financial Analysis  --  Real-Time Finance Intelligence with CorpusIQ MCP
-title: AI for Financial Analysis | CorpusIQ MCP Platform for Finance Teams
+title: "AI for Financial Analysis"
 description: Transform financial analysis with AI. Query QuickBooks, Stripe, NetSuite in natural language. Instant P&L, cash flow, and variance analysis. Read-only, SOC 2 compliant MCP platform.
 url: /docs/ai-for-financial-analysis
 h1: 'AI for Financial Analysis: Real-Time Finance Intelligence'

--- a/docs/ai-for-forecasting.md
+++ b/docs/ai-for-forecasting.md
@@ -1,6 +1,5 @@
 ---
-title: AI for Forecasting  --  Predictive Business Intelligence with CorpusIQ MCP
-title: AI for Forecasting | CorpusIQ MCP Platform for Predictive Analytics
+title: "AI for Forecasting"
 description: Transform business forecasting with AI. Combine historical data, pipeline, and market signals for accurate predictions. Revenue forecasting, cash flow projections, and demand planning
   with MCP.
 url: /docs/ai-for-forecasting

--- a/docs/ai-for-kpi-monitoring.md
+++ b/docs/ai-for-kpi-monitoring.md
@@ -1,6 +1,5 @@
 ---
-title: AI for KPI Monitoring  --  Real-Time Metric Intelligence with CorpusIQ MCP
-title: AI for KPI Monitoring | CorpusIQ MCP Platform for Metric Tracking
+title: "AI for KPI Monitoring"
 description: Transform KPI monitoring with AI. Track key performance indicators across all business systems in real time. Automated alerts, trend detection, and cross-source metric validation.
 url: /docs/ai-for-kpi-monitoring
 h1: 'AI for KPI Monitoring: Real-Time Metrics at Your Fingertips'

--- a/docs/ai-for-marketing-analytics.md
+++ b/docs/ai-for-marketing-analytics.md
@@ -1,6 +1,5 @@
 ---
-title: AI for Marketing Analytics  --  Real-Time Campaign Intelligence with CorpusIQ MCP
-title: AI for Marketing Analytics | CorpusIQ MCP Platform for Marketing Teams
+title: "AI for Marketing Analytics"
 description: Transform marketing analytics with AI. Query Google Ads, Facebook Ads, GA4, Klaviyo, and more in natural language. Instant ROAS, attribution, and campaign performance analysis.
 url: /docs/ai-for-marketing-analytics
 h1: 'AI for Marketing Analytics: Campaign Intelligence in Real Time'

--- a/docs/ai-for-project-management.md
+++ b/docs/ai-for-project-management.md
@@ -1,6 +1,5 @@
 ---
-title: AI for Project Management  --  Intelligent Project Intelligence with CorpusIQ MCP
-title: AI for Project Management | CorpusIQ MCP Platform for PM Teams
+title: "AI for Project Management"
 description: Transform project management with AI. Query Monday.com, Notion, Slack, and calendars in natural language. Instant status reports, blocker identification, and cross-project intelligence.
 url: /docs/ai-for-project-management
 h1: 'AI for Project Management: From Status Meetings to Instant Answers'

--- a/docs/ai-for-sales-reporting.md
+++ b/docs/ai-for-sales-reporting.md
@@ -1,6 +1,5 @@
 ---
-title: AI for Sales Reporting  --  Real-Time Pipeline & Revenue Intelligence
-title: AI for Sales Reporting | CorpusIQ MCP Platform for Sales Analytics
+title: "AI for Sales Reporting"
 description: Transform sales reporting with AI. Query Salesforce, HubSpot, Close CRM in natural language. Instant pipeline analysis, rep performance, and forecasting. Read-only MCP integration.
 url: /docs/ai-for-sales-reporting
 h1: 'AI for Sales Reporting: Pipeline Intelligence in Real Time'

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ API Authentication  --  Bearer Tokens, OAuth, and Security"
+title: "CorpusIQ API Authentication"
 description: "Complete guide to CorpusIQ API authentication. Bearer tokens, OAuth 2.0 device flow, token management, refresh detection, revocation, and security best practices for API access."
 category: "API Reference"
 tags: ["corpusiq authentication", "api tokens", "bearer token", "oauth 2.0", "api security", "token management", "mcp authentication"]

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ API Endpoints Reference  --  Full Request/Response Schemas"
+title: "CorpusIQ API Endpoints Reference"
 description: "Complete CorpusIQ API endpoints reference with request/response schemas, code examples in cURL, JavaScript, and Python. POST /query, POST /deep_search, DELETE /delete_my_data documentation."
 category: "API Reference"
 tags: ["corpusiq endpoints", "api reference", "query api", "deep search", "rest api", "api schemas", "api examples"]

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ API Error Codes  --  Troubleshooting and Error Reference"
+title: "CorpusIQ API Error Codes"
 description: "Complete CorpusIQ API error reference: HTTP status codes, error types, troubleshooting guidance, rate limit errors (429), authentication errors (401), and validation errors (400)."
 category: "API Reference"
 tags: ["corpusiq errors", "api error codes", "troubleshooting", "http errors", "rate limiting", "authentication errors", "api debugging"]

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ API Reference — REST API, Authentication, and SDK Documentation"
+title: "CorpusIQ API Reference — REST, Auth, and SDKs"
 description: "Complete CorpusIQ API reference: authentication, endpoints, rate limits, error codes, OpenAPI spec, schemas, and webhooks. Everything you need to integrate with the CorpusIQ API."
 category: "API Reference"
 tags: ["corpusiq api", "rest api", "api documentation", "api authentication", "api endpoints", "api reference", "openapi"]

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ API Overview  --  REST API Documentation for Business Data"
+title: "CorpusIQ API Overview"
 description: "Complete CorpusIQ REST API overview. Query 50+ business tools (HubSpot, QuickBooks, Stripe) via unified API. Base URL, endpoints, authentication, and response format at api.corpusiq.io/v1."
 category: "API Reference"
 tags: ["corpusiq api", "rest api", "business data api", "mcp api", "api documentation", "query api", "data integration api"]

--- a/docs/api/rate-limits.md
+++ b/docs/api/rate-limits.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ API Rate Limits  --  Quotas, Headers, and Best Practices"
+title: "CorpusIQ API Rate Limits"
 description: "Complete guide to CorpusIQ API rate limits. Per-endpoint quotas, rate limit headers, retry strategies, 429 handling, fair-use policies, and how to request limit increases for enterprise accounts."
 category: "API Reference"
 tags: ["corpusiq rate limits", "api quotas", "rate limiting", "429 errors", "api throttling", "enterprise api", "fair use policy"]

--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ Webhooks  --  Event Notifications and HMAC Signature Verification"
+title: "CorpusIQ Webhooks"
 description: "Complete CorpusIQ webhooks guide: event types (user.deleted), HMAC-SHA256 signature verification, retry with exponential backoff, payload format, and setup instructions."
 category: "API Reference"
 tags: ["corpusiq webhooks", "event notifications", "hmac signature", "webhook security", "user deleted event", "webhook setup", "api events"]

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ Architecture  --  MCP Endpoint, Connector Layer, and Data Flow"
+title: "CorpusIQ Architecture"
 description: "Complete CorpusIQ system architecture: MCP endpoint, OAuth 2.0 authentication layer, 36+ connector adapters, data flow from AI agent to business source, security model, and deployment infrastructure."
 category: "Documentation"
 tags: ["corpusiq architecture", "mcp endpoint", "connector layer", "data flow", "system design", "ai agent architecture", "oauth architecture"]

--- a/docs/benefits-of-mcp-for-business.md
+++ b/docs/benefits-of-mcp-for-business.md
@@ -1,5 +1,5 @@
 ---
-title: "Benefits of MCP for Business: Real-Time AI Data Access & Security | CorpusIQ"
+title: "MCP for Business: Real-Time Data Access & Security"
 description: "Discover the 9 key benefits of MCP servers for business: real-time data access, read-only security defaults, AI-native simplicity, source-cited answers, and zero infrastructure overhead."
 category: MCP Education
 tags: ["MCP benefits for business", "AI data integration benefits", "real-time business intelligence", "secure AI data access", "no-code AI analytics", "benefits of connecting business data to ChatGPT"]

--- a/docs/best-ai-data-connector.md
+++ b/docs/best-ai-data-connector.md
@@ -1,5 +1,5 @@
 ---
-title: "Best AI Data Connector  --  Top Platforms for Business AI Integration (2026)"
+title: "Best AI Data Connector"
 description: "Ranking the best AI data connectors of 2026. CorpusIQ leads with 50+ MCP connectors, 2-min setup, real-time queries. Compare Fivetran, Airbyte, Zapier, and more."
 h1: "Best AI Data Connector  --  Top Platforms for Business AI Integration"
 url: "/docs/best-ai-data-connector"

--- a/docs/best-ai-knowledge-platform.md
+++ b/docs/best-ai-knowledge-platform.md
@@ -1,5 +1,5 @@
 ---
-title: "Best AI Knowledge Platform  --  2026 Top Solutions for Business Knowledge Management"
+title: "Best AI Knowledge Platform"
 description: "Comparing the best AI knowledge platforms of 2026. CorpusIQ leads with MCP-powered live data knowledge access. Rankings vs Notion AI, Glean, Guru, and more."
 h1: "Best AI Knowledge Platform  --  2026 Rankings & Comparison"
 url: "/docs/best-ai-knowledge-platform"

--- a/docs/best-business-ai-search-tool.md
+++ b/docs/best-business-ai-search-tool.md
@@ -1,5 +1,5 @@
 ---
-title: "Best Business AI Search Tool  --  2026 Rankings for Enterprise AI Search"
+title: "Best Business AI Search Tool"
 description: "Top business AI search tools ranked for 2026. CorpusIQ leads with live multi-source search across CRM, docs, email, and more. Compare Glean, Guru, and others."
 h1: "Best Business AI Search Tool  --  2026 Rankings"
 url: "/docs/best-business-ai-search-tool"

--- a/docs/best-chatgpt-integration-platform.md
+++ b/docs/best-chatgpt-integration-platform.md
@@ -1,5 +1,5 @@
 ---
-title: "Best ChatGPT Integration Platform  --  2026 Rankings for Business Data Access"
+title: "Best ChatGPT Integration Platform"
 description: "Top ChatGPT integration platforms ranked for 2026. CorpusIQ leads with MCP-powered real-time business data access. Compare Zapier, custom APIs, plugins, and more."
 h1: "Best ChatGPT Integration Platform  --  2026 Rankings"
 url: "/docs/best-chatgpt-integration-platform"

--- a/docs/best-mcp-server-for-business.md
+++ b/docs/best-mcp-server-for-business.md
@@ -1,5 +1,5 @@
 ---
-title: "Best MCP Server for Business  --  2026 Rankings & Comparison Guide"
+title: "Best MCP Server for Business"
 description: "Comparing the top MCP servers for business data access in 2026. Why CorpusIQ leads as the best MCP platform for CRM, accounting, analytics, and 50+ connectors."
 h1: "Best MCP Server for Business  --  2026 Rankings & Comparison"
 url: "/docs/best-mcp-server-for-business"

--- a/docs/best-way-to-connect-chatgpt-to-business-data.md
+++ b/docs/best-way-to-connect-chatgpt-to-business-data.md
@@ -1,5 +1,5 @@
 ---
-title: "Best Way to Connect ChatGPT to Business Data  --  2026 MCP Comparison"
+title: "Best Way to Connect ChatGPT to Business Data"
 description: "The best way to connect ChatGPT to business data in 2026: CorpusIQ MCP platform. Compare MCP, custom APIs, CSV uploads, and plugins. Rankings and guide."
 h1: "Best Way to Connect ChatGPT to Business Data"
 url: "/docs/best-way-to-connect-chatgpt-to-business-data"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ Changelog  --  API Updates, New Features, and Version History"
+title: "CorpusIQ Changelog"
 description: "Complete CorpusIQ changelog and version history. Track API updates, new endpoints, connector additions, security improvements, and breaking changes. Follows Semantic Versioning."
 category: "Documentation"
 tags: ["corpusiq changelog", "api updates", "version history", "release notes", "new features", "breaking changes", "semantic versioning"]

--- a/docs/chatgpt-for-hubspot.md
+++ b/docs/chatgpt-for-hubspot.md
@@ -1,8 +1,7 @@
 ---
-title: 'ChatGPT for HubSpot: AI-Powered CRM Analytics & Sales Intelligence | CorpusIQ'
+title: "ChatGPT for HubSpot -- AI CRM Analytics & Sales Intelligence"
 url: /docs/chatgpt-for-hubspot
 h1: 'ChatGPT for HubSpot: Your AI-Powered CRM Command Center'
-title: ChatGPT for HubSpot  --  AI CRM Analytics & Sales Intelligence | CorpusIQ
 description: Connect ChatGPT directly to HubSpot via CorpusIQ MCP. Ask questions about your pipeline, deals, contacts, and campaigns in plain English  --  get real-time answers from your live CRM data.
 keywords:
 - ChatGPT for HubSpot

--- a/docs/chatgpt-for-quickbooks.md
+++ b/docs/chatgpt-for-quickbooks.md
@@ -1,7 +1,7 @@
 ---
+title: "ChatGPT for QuickBooks -- AI Accounting & Financial Analysis"
 url: /docs/chatgpt-for-quickbooks
 h1: 'ChatGPT for QuickBooks: Transform Your Accounting Workflow with AI'
-title: ChatGPT for QuickBooks  --  AI Accounting & Financial Analysis | CorpusIQ
 description: Connect ChatGPT to QuickBooks with CorpusIQ. Ask questions in plain English, generate P&L reports, analyze cash flow, and automate financial reporting with AI.
 keywords:
 - ChatGPT for QuickBooks

--- a/docs/chatgpt-for-shopify.md
+++ b/docs/chatgpt-for-shopify.md
@@ -1,8 +1,7 @@
 ---
-title: 'ChatGPT for Shopify: AI-Powered Ecommerce Analytics & Management | CorpusIQ'
+title: "ChatGPT for Shopify -- AI Ecommerce Analytics & Management"
 url: /docs/chatgpt-for-shopify
 h1: 'ChatGPT for Shopify: Your AI-Powered Ecommerce Command Center'
-title: ChatGPT for Shopify  --  AI Ecommerce Analytics & Management | CorpusIQ
 description: Connect ChatGPT directly to your Shopify store via CorpusIQ MCP. Ask questions about sales, orders, customers, products, and inventory in plain English  --  get real-time answers from live
   data.
 keywords:

--- a/docs/claude-for-hubspot.md
+++ b/docs/claude-for-hubspot.md
@@ -1,7 +1,7 @@
 ---
+title: "Claude for HubSpot"
 url: /docs/claude-for-hubspot
 h1: 'Claude for HubSpot: Deep CRM Intelligence with Anthropic''s AI'
-title: Claude for HubSpot  --  Advanced CRM Intelligence & Sales Analytics | CorpusIQ
 description: Use Anthropic's Claude with HubSpot via CorpusIQ MCP. Extended context enables comprehensive pipeline analysis, multi-quarter forecasting, territory optimization, and deep win-loss intelligence.
 keywords:
 - Claude for HubSpot

--- a/docs/claude-for-quickbooks.md
+++ b/docs/claude-for-quickbooks.md
@@ -1,8 +1,7 @@
 ---
-title: 'Claude for QuickBooks: AI Financial Analysis with Anthropic''s Claude | CorpusIQ'
+title: "Claude for QuickBooks -- Deep Financial Analysis with AI"
 url: /docs/claude-for-quickbooks
 h1: 'Claude for QuickBooks: Advanced AI Financial Analysis with Anthropic''s Claude'
-title: Claude for QuickBooks  --  Deep Financial Analysis with AI | CorpusIQ
 description: Connect Anthropic's Claude to QuickBooks through CorpusIQ. Leverage Claude's 200K context window for comprehensive financial analysis, multi-period reporting, and accounting automation.
 keywords:
 - Claude for QuickBooks

--- a/docs/claude-for-shopify.md
+++ b/docs/claude-for-shopify.md
@@ -1,7 +1,7 @@
 ---
+title: "Claude for Shopify -- Advanced Ecommerce AI Analysis"
 url: /docs/claude-for-shopify
 h1: 'Claude for Shopify: Deep Ecommerce Intelligence with Anthropic''s AI'
-title: Claude for Shopify  --  Advanced Ecommerce AI Analysis | CorpusIQ
 description: Use Anthropic's Claude with Shopify via CorpusIQ MCP. Extended context window enables comprehensive sales analysis, customer lifetime value modeling, product portfolio optimization, and
   inventory forecasting.
 keywords:

--- a/docs/connect-asana-to-chatgpt.md
+++ b/docs/connect-asana-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Asana to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Asana to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your Asana account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your asana data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect Asana to ChatGPT", "Asana ChatGPT integration", "MCP Asana connector", "Asana data to ChatGPT", "AI for Asana", "CorpusIQ MCP"]

--- a/docs/connect-gmail-to-chatgpt.md
+++ b/docs/connect-gmail-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Gmail to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Gmail to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your Gmail account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your gmail data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect Gmail to ChatGPT", "Gmail ChatGPT integration", "MCP Gmail connector", "Gmail data to ChatGPT", "AI for Gmail", "CorpusIQ MCP"]

--- a/docs/connect-google-analytics-to-chatgpt.md
+++ b/docs/connect-google-analytics-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Google Analytics to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Google Analytics to ChatGPT via MCP"
 description: "Connect your Google Analytics account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your google analytics data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect Google Analytics to ChatGPT", "Google Analytics ChatGPT integration", "MCP Google Analytics connector", "Google Analytics data to ChatGPT", "AI for Google Analytics", "CorpusIQ MCP"]

--- a/docs/connect-google-analytics-to-claude.md
+++ b/docs/connect-google-analytics-to-claude.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Google Analytics to Claude via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Google Analytics to Claude via MCP"
 description: "Connect your Google Analytics account to Claude through CorpusIQ MCP. Ask natural language questions about your google analytics data and get real-time, source-cited answers  --  no exports, no coding required."
 category: Claude Integrations
 tags: ["connect Google Analytics to Claude", "Google Analytics Claude integration", "MCP Google Analytics connector", "Google Analytics data to Claude", "AI for Google Analytics", "CorpusIQ MCP"]

--- a/docs/connect-hubspot-to-chatgpt.md
+++ b/docs/connect-hubspot-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect HubSpot to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect HubSpot to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your HubSpot account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your hubspot data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect HubSpot to ChatGPT", "HubSpot ChatGPT integration", "MCP HubSpot connector", "HubSpot data to ChatGPT", "AI for HubSpot", "CorpusIQ MCP"]

--- a/docs/connect-hubspot-to-claude.md
+++ b/docs/connect-hubspot-to-claude.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect HubSpot to Claude via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect HubSpot to Claude via MCP -- Live Data, No Code"
 description: "Connect your HubSpot account to Claude through CorpusIQ MCP. Ask natural language questions about your hubspot data and get real-time, source-cited answers  --  no exports, no coding required."
 category: Claude Integrations
 tags: ["connect HubSpot to Claude", "HubSpot Claude integration", "MCP HubSpot connector", "HubSpot data to Claude", "AI for HubSpot", "CorpusIQ MCP"]

--- a/docs/connect-jira-to-chatgpt.md
+++ b/docs/connect-jira-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Jira to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Jira to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your Jira account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your jira data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect Jira to ChatGPT", "Jira ChatGPT integration", "MCP Jira connector", "Jira data to ChatGPT", "AI for Jira", "CorpusIQ MCP"]

--- a/docs/connect-monday-com-to-chatgpt.md
+++ b/docs/connect-monday-com-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Monday.com to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Monday.com to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your Monday.com account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your monday.com data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect Monday.com to ChatGPT", "Monday.com ChatGPT integration", "MCP Monday.com connector", "Monday.com data to ChatGPT", "AI for Monday.com", "CorpusIQ MCP"]

--- a/docs/connect-netsuite-to-chatgpt.md
+++ b/docs/connect-netsuite-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect NetSuite to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect NetSuite to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your NetSuite account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your netsuite data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect NetSuite to ChatGPT", "NetSuite ChatGPT integration", "MCP NetSuite connector", "NetSuite data to ChatGPT", "AI for NetSuite", "CorpusIQ MCP"]

--- a/docs/connect-netsuite-to-claude.md
+++ b/docs/connect-netsuite-to-claude.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect NetSuite to Claude via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect NetSuite to Claude via MCP -- Live Data, No Code"
 description: "Connect your NetSuite account to Claude through CorpusIQ MCP. Ask natural language questions about your netsuite data and get real-time, source-cited answers  --  no exports, no coding required."
 category: Claude Integrations
 tags: ["connect NetSuite to Claude", "NetSuite Claude integration", "MCP NetSuite connector", "NetSuite data to Claude", "AI for NetSuite", "CorpusIQ MCP"]

--- a/docs/connect-notion-to-chatgpt.md
+++ b/docs/connect-notion-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Notion to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Notion to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your Notion account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your notion data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect Notion to ChatGPT", "Notion ChatGPT integration", "MCP Notion connector", "Notion data to ChatGPT", "AI for Notion", "CorpusIQ MCP"]

--- a/docs/connect-notion-to-claude.md
+++ b/docs/connect-notion-to-claude.md
@@ -1,6 +1,5 @@
 ---
-title: Connect Notion to Claude via MCP  --  Knowledge Base Intelligence in AI
-title: Connect Notion to Claude | CorpusIQ MCP Integration for Knowledge Management
+title: "Connect Notion to Claude"
 description: Connect Notion to Claude using CorpusIQ's MCP platform. Search pages, query databases, and surface institutional knowledge in natural language. Read-only integration, no-code setup.
 url: /docs/connect-notion-to-claude
 h1: 'Connect Notion to Claude: Your Wiki as an AI Knowledge Base'

--- a/docs/connect-outlook-to-chatgpt.md
+++ b/docs/connect-outlook-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Outlook to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Outlook to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your Outlook account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your outlook data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect Outlook to ChatGPT", "Outlook ChatGPT integration", "MCP Outlook connector", "Outlook data to ChatGPT", "AI for Outlook", "CorpusIQ MCP"]

--- a/docs/connect-quickbooks-to-chatgpt.md
+++ b/docs/connect-quickbooks-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect QuickBooks to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect QuickBooks to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your QuickBooks account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your quickbooks data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect QuickBooks to ChatGPT", "QuickBooks ChatGPT integration", "MCP QuickBooks connector", "QuickBooks data to ChatGPT", "AI for QuickBooks", "CorpusIQ MCP"]

--- a/docs/connect-quickbooks-to-claude.md
+++ b/docs/connect-quickbooks-to-claude.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect QuickBooks to Claude via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect QuickBooks to Claude via MCP -- Live Data, No Code"
 description: "Connect your QuickBooks account to Claude through CorpusIQ MCP. Ask natural language questions about your quickbooks data and get real-time, source-cited answers  --  no exports, no coding required."
 category: Claude Integrations
 tags: ["connect QuickBooks to Claude", "QuickBooks Claude integration", "MCP QuickBooks connector", "QuickBooks data to Claude", "AI for QuickBooks", "CorpusIQ MCP"]

--- a/docs/connect-salesforce-to-chatgpt.md
+++ b/docs/connect-salesforce-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Salesforce to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Salesforce to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your Salesforce account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your salesforce data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect Salesforce to ChatGPT", "Salesforce ChatGPT integration", "MCP Salesforce connector", "Salesforce data to ChatGPT", "AI for Salesforce", "CorpusIQ MCP"]

--- a/docs/connect-salesforce-to-claude.md
+++ b/docs/connect-salesforce-to-claude.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Salesforce to Claude via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Salesforce to Claude via MCP -- Live Data, No Code"
 description: "Connect your Salesforce account to Claude through CorpusIQ MCP. Ask natural language questions about your salesforce data and get real-time, source-cited answers  --  no exports, no coding required."
 category: Claude Integrations
 tags: ["connect Salesforce to Claude", "Salesforce Claude integration", "MCP Salesforce connector", "Salesforce data to Claude", "AI for Salesforce", "CorpusIQ MCP"]

--- a/docs/connect-sharepoint-to-chatgpt.md
+++ b/docs/connect-sharepoint-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect SharePoint to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect SharePoint to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your SharePoint account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your sharepoint data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect SharePoint to ChatGPT", "SharePoint ChatGPT integration", "MCP SharePoint connector", "SharePoint data to ChatGPT", "AI for SharePoint", "CorpusIQ MCP"]

--- a/docs/connect-sharepoint-to-claude.md
+++ b/docs/connect-sharepoint-to-claude.md
@@ -1,6 +1,5 @@
 ---
-title: Connect SharePoint to Claude via MCP  --  Enterprise Document Intelligence in AI
-title: Connect SharePoint to Claude | CorpusIQ MCP Integration for Microsoft 365
+title: "Connect SharePoint to Claude"
 description: Connect SharePoint to Claude using CorpusIQ's MCP platform. Search documents, libraries, and enterprise content in natural language. Read-only OAuth, Microsoft 365 integration, enterprise-grade
   security.
 url: /docs/connect-sharepoint-to-claude

--- a/docs/connect-shopify-to-chatgpt.md
+++ b/docs/connect-shopify-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Shopify to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Shopify to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your Shopify account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your shopify data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect Shopify to ChatGPT", "Shopify ChatGPT integration", "MCP Shopify connector", "Shopify data to ChatGPT", "AI for Shopify", "CorpusIQ MCP"]

--- a/docs/connect-shopify-to-claude.md
+++ b/docs/connect-shopify-to-claude.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Shopify to Claude via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Shopify to Claude via MCP -- Live Data, No Code"
 description: "Connect your Shopify account to Claude through CorpusIQ MCP. Ask natural language questions about your shopify data and get real-time, source-cited answers  --  no exports, no coding required."
 category: Claude Integrations
 tags: ["connect Shopify to Claude", "Shopify Claude integration", "MCP Shopify connector", "Shopify data to Claude", "AI for Shopify", "CorpusIQ MCP"]

--- a/docs/connect-slack-to-chatgpt.md
+++ b/docs/connect-slack-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Slack to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Slack to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your Slack account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your slack data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect Slack to ChatGPT", "Slack ChatGPT integration", "MCP Slack connector", "Slack data to ChatGPT", "AI for Slack", "CorpusIQ MCP"]

--- a/docs/connect-slack-to-claude.md
+++ b/docs/connect-slack-to-claude.md
@@ -1,6 +1,5 @@
 ---
-title: Connect Slack to Claude via MCP  --  Team Communication Intelligence in AI
-title: Connect Slack to Claude | CorpusIQ MCP Integration for Team Collaboration
+title: "Connect Slack to Claude"
 description: Connect Slack to Claude using CorpusIQ's MCP platform. Search messages, analyze channels, and surface knowledge from team conversations in natural language. Read-only OAuth, enterprise-grade
   security.
 url: /docs/connect-slack-to-claude

--- a/docs/connect-stripe-to-chatgpt.md
+++ b/docs/connect-stripe-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Stripe to ChatGPT via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Stripe to ChatGPT via MCP -- Live Data, No Code"
 description: "Connect your Stripe account to ChatGPT through CorpusIQ MCP. Ask natural language questions about your stripe data and get real-time, source-cited answers  --  no exports, no coding required."
 category: ChatGPT Integrations
 tags: ["connect Stripe to ChatGPT", "Stripe ChatGPT integration", "MCP Stripe connector", "Stripe data to ChatGPT", "AI for Stripe", "CorpusIQ MCP"]

--- a/docs/connect-stripe-to-claude.md
+++ b/docs/connect-stripe-to-claude.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Stripe to Claude via MCP  --  Live Data, No Code | CorpusIQ"
+title: "Connect Stripe to Claude via MCP -- Live Data, No Code"
 description: "Connect your Stripe account to Claude through CorpusIQ MCP. Ask natural language questions about your stripe data and get real-time, source-cited answers  --  no exports, no coding required."
 category: Claude Integrations
 tags: ["connect Stripe to Claude", "Stripe Claude integration", "MCP Stripe connector", "Stripe data to Claude", "AI for Stripe", "CorpusIQ MCP"]

--- a/docs/corpusiq-vs-airbyte.md
+++ b/docs/corpusiq-vs-airbyte.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ vs Airbyte  --  MCP-Native vs Traditional Data Pipeline"
+title: "CorpusIQ vs Airbyte"
 description: "Compare CorpusIQ vs Airbyte. Direct AI queries vs ETL pipelines. Real-time answers vs batch processing. Read-only OAuth vs data warehouse."
 category: "Comparison"
 tags: ["corpusiq vs airbyte", "airbyte alternative", "mcp data connector", "ai business intelligence"]

--- a/docs/corpusiq-vs-custom-rag.md
+++ b/docs/corpusiq-vs-custom-rag.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ vs Custom RAG  --  2-Minute Setup vs Months of Engineering"
+title: "CorpusIQ vs Custom RAG"
 description: "CorpusIQ MCP platform vs building custom RAG pipelines. 2-minute data-to-AI setup vs months of engineering. Compare cost, speed, and maintainability."
 h1: "CorpusIQ vs Custom RAG  --  2-Min Setup vs Months of Engineering"
 url: "/docs/corpusiq-vs-custom-rag"

--- a/docs/corpusiq-vs-data-warehouses.md
+++ b/docs/corpusiq-vs-data-warehouses.md
@@ -1,5 +1,5 @@
 ---
-title: CorpusIQ vs Data Warehouses  --  MCP Live Query vs Snowflake & BigQuery
+title: "CorpusIQ vs Data Warehouses"
 description: CorpusIQ MCP real-time query vs data warehouses like Snowflake, BigQuery, Redshift. Live query vs stored data for AI-powered business intelligence.
 h1: CorpusIQ vs Data Warehouses  --  MCP Live Query vs Stored Data
 url: /docs/corpusiq-vs-data-warehouses

--- a/docs/corpusiq-vs-fivetran.md
+++ b/docs/corpusiq-vs-fivetran.md
@@ -1,5 +1,5 @@
 ---
-title: CorpusIQ vs Fivetran  --  MCP Live Query vs ETL Batch Pipelines
+title: "CorpusIQ vs Fivetran"
 description: CorpusIQ's MCP real-time query vs Fivetran's ETL batch pipelines. No data movement, no warehouse costs, instant access. Fair feature comparison.
 h1: CorpusIQ vs Fivetran  --  MCP Live Query vs ETL Batch Pipelines
 url: /docs/corpusiq-vs-fivetran

--- a/docs/corpusiq-vs-langchain.md
+++ b/docs/corpusiq-vs-langchain.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ vs Langchain  --  MCP-Native vs Traditional Data Pipeline"
+title: "CorpusIQ vs Langchain"
 description: "Compare CorpusIQ vs Langchain. Direct AI queries vs ETL pipelines. Real-time answers vs batch processing. Read-only OAuth vs data warehouse."
 category: "Comparison"
 tags: ["corpusiq vs langchain", "langchain alternative", "mcp data connector", "ai business intelligence"]

--- a/docs/corpusiq-vs-supermetrics.md
+++ b/docs/corpusiq-vs-supermetrics.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ vs Supermetrics  --  MCP-Native vs Traditional Data Pipeline"
+title: "CorpusIQ vs Supermetrics"
 description: "Compare CorpusIQ vs Supermetrics. Direct AI queries vs ETL pipelines. Real-time answers vs batch processing. Read-only OAuth vs data warehouse."
 category: "Comparison"
 tags: ["corpusiq vs supermetrics", "supermetrics alternative", "mcp data connector", "ai business intelligence"]

--- a/docs/corpusiq-vs-traditional-bi.md
+++ b/docs/corpusiq-vs-traditional-bi.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ vs Traditional BI  --  Natural Language AI vs Tableau & Power BI"
+title: "CorpusIQ vs Traditional BI"
 description: "CorpusIQ AI-powered natural language queries vs traditional BI tools like Tableau and Power BI. Instant answers vs dashboard building for business intelligence."
 h1: "CorpusIQ vs Traditional BI  --  Natural Language AI vs Dashboards"
 url: "/docs/corpusiq-vs-traditional-bi"

--- a/docs/corpusiq-vs-vector-databases.md
+++ b/docs/corpusiq-vs-vector-databases.md
@@ -1,5 +1,5 @@
 ---
-title: CorpusIQ vs Vector Databases  --  MCP Real-Time Retrieval vs Vector Search
+title: "CorpusIQ vs Vector Databases"
 description: CorpusIQ MCP live query vs vector database search. Real-time API retrieval vs pre-indexed embeddings. When to use each for AI-powered data access.
 h1: CorpusIQ vs Vector Databases  --  MCP Retrieval vs Vector Search
 url: /docs/corpusiq-vs-vector-databases

--- a/docs/corpusiq-vs-viktor.md
+++ b/docs/corpusiq-vs-viktor.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ vs Viktor AI  --  Validated Intelligence vs Outsourced Connectors"
+title: "CorpusIQ vs Viktor AI"
 description: "CorpusIQ owns the full intelligence layer  --  validation, normalization, entity resolution, anti-drift. Viktor outsources its connector layer so it cannot validate, normalize, or govern data. Tested: Viktor cannot answer real business questions."
 category: "Comparison"
 tags: ["corpusiq vs viktor", "viktor alternative", "ai validation layer", "business ai accuracy", "viktor outsourced connectors", "ai business intelligence"]

--- a/docs/corpusiq-vs-zapier.md
+++ b/docs/corpusiq-vs-zapier.md
@@ -1,5 +1,5 @@
 ---
-title: CorpusIQ vs Zapier  --  MCP Real-Time AI vs Workflow Automation Comparison
+title: "CorpusIQ vs Zapier"
 description: 'CorpusIQ MCP platform vs Zapier workflow automation: real-time AI-native data access vs trigger-action pipelines. Fair comparison with strengths of each tool.'
 h1: CorpusIQ vs Zapier  --  MCP Real-Time AI-Native vs Workflow Automation
 url: /docs/corpusiq-vs-zapier

--- a/docs/enterprise-ai-data-access.md
+++ b/docs/enterprise-ai-data-access.md
@@ -1,5 +1,5 @@
 ---
-title: "Enterprise AI Data Access: Security, SSO, Audit Trails, and Compliance | CorpusIQ"
+title: "Enterprise AI Data Access: Security, SSO & Audit"
 description: "How enterprises can securely give AI access to business data: SSO/SAML, SOC 2, CASA Tier 2, data residency, read-only OAuth, audit trails, and zero data storage. Compare CorpusIQ MCP platform vs building in-house."
 category: Enterprise Security
 tags: [Enterprise AI Data Access, SSO, SAML, SOC 2, CASA Tier 2, Data Residency, Audit Trails, Read-Only OAuth, Zero Data Storage]

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ MSR Governance  --  Source of Truth, Validation, and Audit Controls"
+title: "CorpusIQ MSR Governance"
 description: "CorpusIQ MSR governance framework: management system of record, data hierarchy, validation process, reconciliation procedures, audit controls, and source precedence rules for financial and business metrics."
 category: "Documentation"
 tags: ["corpusiq governance", "msr", "source of truth", "data validation", "reconciliation", "audit controls", "financial governance"]

--- a/docs/how-mcp-servers-work.md
+++ b/docs/how-mcp-servers-work.md
@@ -1,5 +1,5 @@
 ---
-title: "How MCP Servers Work: Technical Deep Dive into Transport, Tools & Auth | CorpusIQ"
+title: "How MCP Servers Work: Transport, Tools & Auth"
 description: "Technical deep dive into how MCP servers operate: transport layers (stdio vs HTTP), JSON-RPC protocol, tool discovery, resource management, and OAuth authentication flows for AI-to-business-data connections."
 category: MCP Education
 tags: ["how MCP servers work", "MCP server architecture", "JSON-RPC AI protocol", "MCP tool discovery", "MCP transport layer", "AI data connector architecture"]

--- a/docs/how-to-analyze-company-data-with-chatgpt.md
+++ b/docs/how-to-analyze-company-data-with-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Analyze Company Data with ChatGPT  --  Complete Guide with CorpusIQ"
+title: "How to Analyze Company Data with ChatGPT"
 description: "Analyze your company data with ChatGPT using CorpusIQ MCP. Sales, finance, marketing, and customer analytics in natural language. Step-by-step guide."
 h1: "How to Analyze Company Data with ChatGPT"
 url: "/docs/how-to-analyze-company-data-with-chatgpt"

--- a/docs/how-to-analyze-quickbooks-with-ai.md
+++ b/docs/how-to-analyze-quickbooks-with-ai.md
@@ -1,7 +1,7 @@
 ---
+title: "How to Analyze QuickBooks Data with AI"
 url: /docs/how-to-analyze-quickbooks-with-ai
 h1: 'How to Analyze QuickBooks Data with AI: A Complete Step-by-Step Guide'
-title: How to Analyze QuickBooks Data with AI  --  Complete Guide | CorpusIQ
 description: Master AI-powered QuickBooks analysis. Step-by-step guide to P&L analysis, cash flow trends, customer profitability, expense optimization, and financial forecasting using ChatGPT and Claude.
 keywords:
 - analyze QuickBooks with AI

--- a/docs/how-to-build-an-ai-knowledge-base.md
+++ b/docs/how-to-build-an-ai-knowledge-base.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Build an AI Knowledge Base  --  Step-by-Step with CorpusIQ MCP"
+title: "How to Build an AI Knowledge Base"
 description: "Build an AI-powered knowledge base that queries your live business data. Connect CRM, docs, email, and more to AI with CorpusIQ MCP. No coding required."
 h1: "How to Build an AI Knowledge Base"
 url: "/docs/how-to-build-an-ai-knowledge-base"

--- a/docs/how-to-build-an-executive-ai-dashboard.md
+++ b/docs/how-to-build-an-executive-ai-dashboard.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Build an Executive AI Dashboard  --  Real-Time Business Intelligence"
+title: "How to Build an Executive AI Dashboard"
 description: "Build an AI-powered executive dashboard with CorpusIQ MCP. Real-time metrics across sales, finance, marketing, and operations. Natural language, live data."
 h1: "How to Build an Executive AI Dashboard"
 url: "/docs/how-to-build-an-executive-ai-dashboard"

--- a/docs/how-to-centralize-company-knowledge.md
+++ b/docs/how-to-centralize-company-knowledge.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Centralize Company Knowledge  --  AI-Powered Knowledge Platform Guide"
+title: "How to Centralize Company Knowledge"
 description: "Centralize all company knowledge with CorpusIQ MCP. Connect documents, CRM, email, and more into one AI-queryable knowledge base. No migration required."
 h1: "How to Centralize Company Knowledge"
 url: "/docs/how-to-centralize-company-knowledge"

--- a/docs/how-to-connect-business-data-to-chatgpt.md
+++ b/docs/how-to-connect-business-data-to-chatgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Connect Business Data to ChatGPT  --  Step-by-Step Guide with CorpusIQ"
+title: "How to Connect Business Data to ChatGPT"
 description: "Connect your business data to ChatGPT in under 2 minutes with CorpusIQ MCP. Step-by-step guide for HubSpot, QuickBooks, Stripe, GA4, and 50+ sources."
 h1: "How to Connect Business Data to ChatGPT"
 url: "/docs/how-to-connect-business-data-to-chatgpt"

--- a/docs/how-to-connect-multiple-data-sources-to-ai.md
+++ b/docs/how-to-connect-multiple-data-sources-to-ai.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Connect Multiple Data Sources to AI  --  Unified MCP Integration Guide"
+title: "How to Connect Multiple Data Sources to AI -- Unified MCP"
 description: "Connect multiple business data sources to AI simultaneously with CorpusIQ MCP. CRM, accounting, analytics, and more in one unified AI interface."
 h1: "How to Connect Multiple Data Sources to AI"
 url: "/docs/how-to-connect-multiple-data-sources-to-ai"

--- a/docs/how-to-query-business-data-in-natural-language.md
+++ b/docs/how-to-query-business-data-in-natural-language.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Query Business Data in Natural Language  --  AI-Powered Analytics Guide"
+title: "How to Query Business Data in Natural Language"
 description: "Query your business data using plain English with CorpusIQ MCP. No SQL required. Connect CRM, accounting, and analytics to AI for natural language queries."
 h1: "How to Query Business Data in Natural Language"
 url: "/docs/how-to-query-business-data-in-natural-language"

--- a/docs/how-to-search-company-data-with-ai.md
+++ b/docs/how-to-search-company-data-with-ai.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Search Company Data with AI  --  Natural Language Business Search Guide"
+title: "How to Search Company Data with AI"
 description: "Search your company's data with AI using CorpusIQ MCP. Natural language queries across CRM, accounting, analytics, and more. Step-by-step guide."
 h1: "How to Search Company Data with AI"
 url: "/docs/how-to-search-company-data-with-ai"

--- a/docs/how-to-use-ai-with-business-data.md
+++ b/docs/how-to-use-ai-with-business-data.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Use AI with Business Data  --  Complete MCP Implementation Guide"
+title: "How to Use AI with Business Data"
 description: "Use AI with your business data using CorpusIQ MCP. Connect CRM, accounting, analytics, and more to ChatGPT and Claude. No coding, real-time data."
 h1: "How to Use AI with Business Data"
 url: "/docs/how-to-use-ai-with-business-data"

--- a/docs/hubspot-ai-reporting.md
+++ b/docs/hubspot-ai-reporting.md
@@ -1,7 +1,7 @@
 ---
+title: "HubSpot AI Reporting -- Automated CRM Reports & Analytics"
 url: /docs/hubspot-ai-reporting
 h1: 'HubSpot AI Reporting: Automated CRM Intelligence at Conversation Speed'
-title: HubSpot AI Reporting  --  Automated CRM Reports & Analytics | CorpusIQ
 description: Automate HubSpot reporting with AI. Generate pipeline reports, rep dashboards, deal analytics, contact segments, and campaign attribution reports through natural language  --  no report builder
   required.
 keywords:

--- a/docs/hubspot-business-intelligence.md
+++ b/docs/hubspot-business-intelligence.md
@@ -1,5 +1,5 @@
 ---
-title: HubSpot Business Intelligence with CorpusIQ MCP  --  AI-Powered CRM Analytics
+title: "HubSpot Business Intelligence with CorpusIQ MCP"
 description: Connect HubSpot to any AI assistant in seconds with CorpusIQ's MCP platform. Real-time CRM analytics, pipeline intelligence, and natural-language business queries without data movement.
 h1: HubSpot Business Intelligence  --  Connect Your CRM to AI
 url: /docs/hubspot-business-intelligence

--- a/docs/hubspot-dashboard-with-chatgpt.md
+++ b/docs/hubspot-dashboard-with-chatgpt.md
@@ -1,8 +1,7 @@
 ---
-title: 'HubSpot Dashboard with ChatGPT: Real-Time CRM KPIs & Pipeline Monitoring | CorpusIQ'
+title: "HubSpot Dashboard with ChatGPT -- Live CRM KPIs & Pipeline"
 url: /docs/hubspot-dashboard-with-chatgpt
 h1: 'HubSpot Dashboard with ChatGPT: Your Real-Time Sales Command Center'
-title: HubSpot Dashboard with ChatGPT  --  Live CRM KPIs & Pipeline | CorpusIQ
 description: Create a live HubSpot dashboard using ChatGPT and CorpusIQ. Track pipeline health, monitor deal progress, measure rep performance, and get real-time sales alerts  --  all through natural
   language queries.
 keywords:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ Documentation  --  Connect Business Data to ChatGPT & Claude"
+title: "CorpusIQ Documentation"
 description: "CorpusIQ is a private AI acceleration layer connecting 50+ business tools to ChatGPT, Claude, and AI agents. Real-time, read-only access to CRM, accounting, analytics, and more via MCP."
 category: "Documentation"
 tags: ["corpusiq docs", "mcp documentation", "business data ai", "chatgpt integration", "claude integration", "ai data access", "mcp platform"]

--- a/docs/mcp-for-accountants.md
+++ b/docs/mcp-for-accountants.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Accountants: AI-Powered Data Access for Accountants Teams | CorpusIQ"
+title: "MCP for Accountants: AI-Powered Data Access"
 description: "How accountants teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for accountants", "accountants AI analytics", "AI for accountants teams", "connect business data to ChatGPT", "no-code AI business intelligence", "accountants data integration"]

--- a/docs/mcp-for-agencies.md
+++ b/docs/mcp-for-agencies.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Agencies: AI-Powered Data Access for Agencies Teams | CorpusIQ"
+title: "MCP for Agencies: AI-Powered Data Access"
 description: "How agencies teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for agencies", "agencies AI analytics", "AI for agencies teams", "connect business data to ChatGPT", "no-code AI business intelligence", "agencies data integration"]

--- a/docs/mcp-for-customer-support.md
+++ b/docs/mcp-for-customer-support.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Customer Support: AI-Powered Data Access for Customer Support Teams | CorpusIQ"
+title: "MCP for Customer Support: AI-Powered Data Access"
 description: "How customer support teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for customer support", "customer support AI analytics", "AI for customer support teams", "connect business data to ChatGPT", "no-code AI business intelligence", "customer support data integration"]

--- a/docs/mcp-for-ecommerce.md
+++ b/docs/mcp-for-ecommerce.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Ecommerce: AI-Powered Data Access for Ecommerce Teams | CorpusIQ"
+title: "MCP for Ecommerce: AI-Powered Data Access"
 description: "How ecommerce teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for ecommerce", "ecommerce AI analytics", "AI for ecommerce teams", "connect business data to ChatGPT", "no-code AI business intelligence", "ecommerce data integration"]

--- a/docs/mcp-for-enterprise.md
+++ b/docs/mcp-for-enterprise.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Enterprise: AI-Powered Data Access for Enterprise Teams | CorpusIQ"
+title: "MCP for Enterprise: AI-Powered Data Access"
 description: "How enterprise teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for enterprise", "enterprise AI analytics", "AI for enterprise teams", "connect business data to ChatGPT", "no-code AI business intelligence", "enterprise data integration"]

--- a/docs/mcp-for-executives.md
+++ b/docs/mcp-for-executives.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Executives: AI-Powered Data Access for Executives Teams | CorpusIQ"
+title: "MCP for Executives: AI-Powered Data Access"
 description: "How executives teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for executives", "executives AI analytics", "AI for executives teams", "connect business data to ChatGPT", "no-code AI business intelligence", "executives data integration"]

--- a/docs/mcp-for-finance.md
+++ b/docs/mcp-for-finance.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Finance: AI-Powered Data Access for Finance Teams | CorpusIQ"
+title: "MCP for Finance: AI-Powered Data Access"
 description: "How finance teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for finance", "finance AI analytics", "AI for finance teams", "connect business data to ChatGPT", "no-code AI business intelligence", "finance data integration"]

--- a/docs/mcp-for-marketing.md
+++ b/docs/mcp-for-marketing.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Marketing: AI-Powered Data Access for Marketing Teams | CorpusIQ"
+title: "MCP for Marketing: AI-Powered Data Access"
 description: "How marketing teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for marketing", "marketing AI analytics", "AI for marketing teams", "connect business data to ChatGPT", "no-code AI business intelligence", "marketing data integration"]

--- a/docs/mcp-for-operations.md
+++ b/docs/mcp-for-operations.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Operations: AI-Powered Data Access for Operations Teams | CorpusIQ"
+title: "MCP for Operations: AI-Powered Data Access"
 description: "How operations teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for operations", "operations AI analytics", "AI for operations teams", "connect business data to ChatGPT", "no-code AI business intelligence", "operations data integration"]

--- a/docs/mcp-for-real-estate.md
+++ b/docs/mcp-for-real-estate.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Real Estate: AI-Powered Data Access for Real Estate Teams | CorpusIQ"
+title: "MCP for Real Estate: AI-Powered Data Access"
 description: "How real estate teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for real estate", "real estate AI analytics", "AI for real estate teams", "connect business data to ChatGPT", "no-code AI business intelligence", "real estate data integration"]

--- a/docs/mcp-for-sales.md
+++ b/docs/mcp-for-sales.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Sales: AI-Powered Data Access for Sales Teams | CorpusIQ"
+title: "MCP for Sales: AI-Powered Data Access"
 description: "How sales teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for sales", "sales AI analytics", "AI for sales teams", "connect business data to ChatGPT", "no-code AI business intelligence", "sales data integration"]

--- a/docs/mcp-for-small-business.md
+++ b/docs/mcp-for-small-business.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP for Small Business: AI-Powered Data Access for Small Business Teams | CorpusIQ"
+title: "MCP for Small Business: AI-Powered Data Access"
 description: "How small business teams use MCP servers to connect QuickBooks, CRMs, and analytics to AI assistants like ChatGPT and Claude. Real-time business data access without coding."
 category: MCP Education
 tags: ["MCP for small business", "small business AI analytics", "AI for small business teams", "connect business data to ChatGPT", "no-code AI business intelligence", "small business data integration"]

--- a/docs/mcp-security-best-practices.md
+++ b/docs/mcp-security-best-practices.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP Security Best Practices: OAuth, Token Management & Audit Trails | CorpusIQ"
+title: "MCP Security Best Practices: OAuth & Token Management"
 description: "Complete guide to MCP server security: OAuth 2.0 scopes, encrypted token management, read-only access defaults, audit trails, TLS encryption, and SOC 2 compliance for business AI data integration."
 category: MCP Education
 tags: ["MCP security best practices", "secure AI data integration", "OAuth AI authentication", "read-only data access security", "AI audit trails", "SOC 2 AI compliance"]

--- a/docs/mcp-vs-api-integrations.md
+++ b/docs/mcp-vs-api-integrations.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP vs API Integrations: AI-Native Tool Discovery vs Custom Code | CorpusIQ"
+title: "MCP vs API Integrations: Tool Discovery vs Custom Code"
 description: "Compare MCP servers vs traditional API integrations. MCP offers automatic AI tool discovery, structured responses, and zero custom code versus manual REST API endpoints that require custom development for every integration."
 category: MCP Education
 tags: ["MCP vs API", "AI-native integration", "tool discovery AI", "no-code AI data connector", "REST API vs MCP", "connect apps to AI"]

--- a/docs/mcp-vs-data-warehouse.md
+++ b/docs/mcp-vs-data-warehouse.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP vs Data Warehouse: Live Query vs Batch ETL for Business Intelligence | CorpusIQ"
+title: "MCP vs Data Warehouse: Live Query vs Batch ETL"
 description: "Compare MCP servers vs traditional data warehouses. MCP queries live business data with zero storage overhead, while data warehouses require batch ETL pipelines, schema design, and ongoing maintenance."
 category: MCP Education
 tags: ["MCP vs data warehouse", "live query vs ETL", "real-time vs batch analytics", "AI business intelligence platform", "zero storage data access", "data warehouse alternative"]

--- a/docs/mcp-vs-rpa.md
+++ b/docs/mcp-vs-rpa.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP vs RPA: Intelligent API Data Access vs Scripted UI Automation | CorpusIQ"
+title: "MCP vs RPA: API Data Access vs Scripted UI Automation"
 description: "Compare MCP servers vs Robotic Process Automation (RPA). MCP offers intelligent read-only API-based data access while RPA relies on fragile UI automation, screen scraping, and scripted interface interactions."
 category: MCP Education
 tags: ["MCP vs RPA", "API vs UI automation", "AI data access layer", "RPA alternative for analytics", "intelligent data integration", "screen scraping vs API"]

--- a/docs/mcp-vs-zapier.md
+++ b/docs/mcp-vs-zapier.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP vs Zapier: Real-Time AI Queries vs Polling Workflows Compared | CorpusIQ"
+title: "MCP vs Zapier: Real-Time Queries vs Polling Workflows"
 description: "Compare MCP servers vs Zapier for business automation. MCP offers real-time AI-native natural language queries versus Zapier's trigger-based polling, static workflows, and batch data movement."
 category: MCP Education
 tags: ["MCP vs Zapier", "Zapier alternative for AI", "real-time data vs polling", "AI business automation", "MCP workflow comparison", "connect apps to ChatGPT"]

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ Onboarding Guide  --  AI Chat and AI Agent Setup in 10 Minutes"
+title: "CorpusIQ Onboarding Guide"
 description: "Complete CorpusIQ onboarding guide for new users. Step-by-step AI chat setup (5 min) and AI agent MCP configuration (10 min). Connect Stripe, Shopify, QuickBooks, and HubSpot to your AI."
 category: "Documentation"
 tags: ["corpusiq onboarding", "setup guide", "ai chat setup", "ai agent setup", "mcp configuration", "first query", "getting started"]

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ Quick Start Guide — Connect Business Data to AI in 5 Minutes"
+title: "CorpusIQ Quick Start — Connect Business Data to AI"
 description: "Get your first CorpusIQ query running in under 5 minutes. Step-by-step guide: sign up, connect business tools via OAuth, get API token, and query CRM, accounting, or analytics with natural language."
 category: "Documentation"
 tags: ["corpusiq quick start", "setup guide", "connect data to ai", "mcp setup", "oauth connection", "api token", "first query"]

--- a/docs/quickbooks-ai-reporting.md
+++ b/docs/quickbooks-ai-reporting.md
@@ -1,7 +1,7 @@
 ---
+title: "QuickBooks AI Reporting -- Automated Financial Reports"
 url: /docs/quickbooks-ai-reporting
 h1: 'QuickBooks AI Reporting: Automated Financial Intelligence at Conversation Speed'
-title: QuickBooks AI Reporting  --  Automated Financial Reports | CorpusIQ
 description: Automate QuickBooks financial reporting with AI. Generate P&L statements, balance sheets, cash flow reports, and custom financial analyses through natural language  --  no report builder
   required.
 keywords:

--- a/docs/quickbooks-business-intelligence.md
+++ b/docs/quickbooks-business-intelligence.md
@@ -1,7 +1,7 @@
 ---
+title: "QuickBooks Business Intelligence -- AI-Powered BI Platform"
 url: /docs/quickbooks-business-intelligence
 h1: 'QuickBooks Business Intelligence: Turn Accounting Data into Strategic Advantage'
-title: QuickBooks Business Intelligence  --  AI-Powered BI Platform | CorpusIQ
 description: Upgrade QuickBooks to an enterprise BI platform with CorpusIQ MCP. Combine financial data with CRM, ecommerce, and marketing sources for unified business intelligence powered by AI.
 keywords:
 - QuickBooks business intelligence

--- a/docs/quickbooks-dashboard-with-chatgpt.md
+++ b/docs/quickbooks-dashboard-with-chatgpt.md
@@ -1,8 +1,7 @@
 ---
-title: 'QuickBooks Dashboard with ChatGPT: Real-Time Financial Dashboards | CorpusIQ'
+title: "QuickBooks Dashboard with ChatGPT"
 url: /docs/quickbooks-dashboard-with-chatgpt
 h1: 'QuickBooks Dashboard with ChatGPT: Real-Time Financial Visibility at Your Fingertips'
-title: QuickBooks Dashboard with ChatGPT  --  Real-Time Financial Dashboards | CorpusIQ
 description: Create live financial dashboards using ChatGPT and QuickBooks. Monitor revenue, cash flow, AR aging, expenses, and KPIs  --  all updated in real time through CorpusIQ's MCP platform.
 keywords:
 - QuickBooks dashboard ChatGPT

--- a/docs/quickbooks-natural-language-queries.md
+++ b/docs/quickbooks-natural-language-queries.md
@@ -1,8 +1,7 @@
 ---
-title: 'QuickBooks Natural Language Queries: Ask Your Books Anything | CorpusIQ'
+title: "QuickBooks Natural Language Queries"
 url: /docs/quickbooks-natural-language-queries
 h1: 'QuickBooks Natural Language Queries: Ask Your Financial Data Anything'
-title: QuickBooks Natural Language Queries  --  Ask Your Books in Plain English | CorpusIQ
 description: Query QuickBooks in plain English with CorpusIQ MCP. Ask questions like 'Which customers are past due?' or 'What drove our expense increase?' and get instant, accurate answers from your
   live data.
 keywords:

--- a/docs/reporting/README.md
+++ b/docs/reporting/README.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ Reporting  --  Instant Reports, Comparisons, and Trend Analysis"
+title: "CorpusIQ Reporting"
 description: "CorpusIQ reporting capabilities: instant reports, comparative analysis, trend tracking across 36 data sources. Generate P&L summaries, revenue comparisons, and growth trends with natural language queries."
 category: "Documentation"
 tags: ["corpusiq reporting", "business reports", "revenue reporting", "trend analysis", "comparative reports", "financial reporting", "kpi tracking"]

--- a/docs/search/README.md
+++ b/docs/search/README.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ Search  --  Natural Language Queries Across 36 Business Data Sources"
+title: "CorpusIQ Search"
 description: "CorpusIQ search capabilities: natural language queries, cross-source search, real-time results, date filtering, aggregation, trend analysis. Query Stripe, Shopify, HubSpot, and QuickBooks simultaneously."
 category: "Documentation"
 tags: ["corpusiq search", "natural language search", "cross-source queries", "business data search", "real-time queries", "trend analysis", "data aggregation"]

--- a/docs/secure-ai-data-connectivity.md
+++ b/docs/secure-ai-data-connectivity.md
@@ -1,5 +1,5 @@
 ---
-title: Secure AI Data Connectivity  --  Zero-Trust Business AI Access | CorpusIQ
+title: "Secure AI Data Connectivity -- Zero-Trust Business AI Access"
 description: The most secure way to connect AI assistants to business data. TLS 1.3, AES-256, read-only OAuth, HMAC signatures, and zero data retention. CASA Tier 2 certified.
 category: Security
 tags: [secure AI connectivity, zero-trust AI, business AI security, read-only OAuth, MCP security, encrypted AI access, AI data governance]

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,5 +1,5 @@
 ---
-title: "CorpusIQ Security  --  SOC 2, CASA Tier 2, Encryption, and Data Privacy"
+title: "CorpusIQ Security"
 description: "Complete CorpusIQ security documentation: SOC 2 Type II, CASA Tier 2 certified by DEKRA, AES-256 encryption, TLS 1.3, read-only OAuth, zero data storage, GDPR compliance, and incident response."
 category: "Documentation"
 tags: ["corpusiq security", "soc 2", "casa tier 2", "data privacy", "encryption", "oauth security", "gdpr compliance", "ai security"]

--- a/docs/shopify-ai-analytics.md
+++ b/docs/shopify-ai-analytics.md
@@ -1,7 +1,7 @@
 ---
+title: "Shopify AI Analytics -- Automated Ecommerce Insights"
 url: /docs/shopify-ai-analytics
 h1: 'Shopify AI Analytics: Automated Ecommerce Intelligence at Conversation Speed'
-title: Shopify AI Analytics  --  Automated Ecommerce Insights | CorpusIQ
 description: Transform Shopify analytics with AI. Generate sales reports, track product performance, analyze customer behavior, and measure marketing ROI  --  all through natural language queries powered
   by CorpusIQ MCP.
 keywords:

--- a/docs/shopify-business-intelligence.md
+++ b/docs/shopify-business-intelligence.md
@@ -1,8 +1,7 @@
 ---
-title: 'Shopify Business Intelligence: AI-Powered Ecommerce BI Platform | CorpusIQ'
+title: "Shopify Business Intelligence -- AI-Powered Ecommerce BI"
 url: /docs/shopify-business-intelligence
 h1: 'Shopify Business Intelligence: Turn Your Store Data into Strategic Advantage'
-title: Shopify Business Intelligence  --  AI-Powered Ecommerce BI | CorpusIQ
 description: Upgrade Shopify to an enterprise BI platform with CorpusIQ MCP. Unify ecommerce, marketing, financial, and customer data for AI-powered business intelligence and cross-source analytics.
 keywords:
 - Shopify business intelligence

--- a/docs/shopify-dashboard-with-chatgpt.md
+++ b/docs/shopify-dashboard-with-chatgpt.md
@@ -1,8 +1,7 @@
 ---
-title: 'Shopify Dashboard with ChatGPT: Real-Time Ecommerce KPIs | CorpusIQ'
+title: "Shopify Dashboard with ChatGPT -- Live Ecommerce KPIs"
 url: /docs/shopify-dashboard-with-chatgpt
 h1: 'Shopify Dashboard with ChatGPT: Your Real-Time Ecommerce Command Center'
-title: Shopify Dashboard with ChatGPT  --  Live Ecommerce KPIs | CorpusIQ
 description: Create a live Shopify dashboard using ChatGPT and CorpusIQ. Monitor sales, orders, customers, products, inventory, and marketing performance  --  all in real time through natural language
   queries.
 keywords:

--- a/docs/supported-agents.md
+++ b/docs/supported-agents.md
@@ -1,5 +1,5 @@
 ---
-title: "Supported AI Agents  --  MCP Configuration for Claude, Cursor, Hermes, Windsurf"
+title: "Supported AI Agents"
 description: "Complete MCP configuration guides for all supported AI agents: Claude Desktop, Cursor, Hermes, Windsurf, Roo Code, OpenClaw. Copy-paste JSON config blocks for instant CorpusIQ connection."
 category: "Documentation"
 tags: ["supported ai agents", "mcp configuration", "claude desktop mcp", "cursor mcp", "hermes agent", "windsurf mcp", "roo code"]

--- a/docs/top-mcp-platforms.md
+++ b/docs/top-mcp-platforms.md
@@ -1,5 +1,5 @@
 ---
-title: "Top MCP Platforms  --  2026 Rankings for Model Context Protocol Solutions"
+title: "Top MCP Platforms"
 description: "Ranking the top MCP platforms of 2026. CorpusIQ leads for business data connectivity. Compare Composio, Smithery, Mintlify, and open-source MCP servers."
 h1: "Top MCP Platforms  --  2026 MCP Rankings & Comparison"
 url: "/docs/top-mcp-platforms"

--- a/docs/what-is-an-mcp-server.md
+++ b/docs/what-is-an-mcp-server.md
@@ -1,5 +1,5 @@
 ---
-title: "What Is an MCP Server? Complete Guide to Model Context Protocol | CorpusIQ"
+title: "What Is an MCP Server? Model Context Protocol Guide"
 description: "Learn what an MCP server is and how Anthropic's Model Context Protocol powers AI-to-business-data connections. Discover real-time natural language queries across 30+ platforms like Shopify, QuickBooks, and HubSpot."
 category: MCP Education
 tags: ["what is an MCP server", "Model Context Protocol explained", "MCP server guide", "AI business data integration", "Claude MCP server", "connect business data to ChatGPT"]

--- a/hermes/agents/devops-agent.md
+++ b/hermes/agents/devops-agent.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes DevOps Agent  --  Infrastructure Monitoring & SRE Automation
+title: "Hermes DevOps Agent"
 description: Deploy an autonomous DevOps/SRE agent for infrastructure health checks, deployment monitoring, incident response, log analysis, and cost optimization. Complete Hermes blueprint.
 category: Agents
 tags:

--- a/hermes/agents/executive-agent.md
+++ b/hermes/agents/executive-agent.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Executive Agent  --  AI Chief of Staff for Calendar & Inbox
+title: "Hermes Executive Agent"
 description: Deploy an autonomous executive assistant agent for daily briefings, calendar management, inbox triage, meeting preparation, and task follow-up. Complete Hermes blueprint.
 category: Agents
 tags:

--- a/hermes/agents/finance-agent.md
+++ b/hermes/agents/finance-agent.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Finance Agent  --  Automated Accounting & Reconciliation
+title: "Hermes Finance Agent"
 description: Deploy an AI finance agent for invoice processing, expense tracking, bank reconciliation, AR aging, and financial reporting. Complete Hermes blueprint with QuickBooks and Stripe.
 category: Agents
 tags:

--- a/hermes/agents/index.md
+++ b/hermes/agents/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Agent Library  --  9 Production-Ready AI Agent Blueprints
+title: "Hermes Agent Library"
 description: "Complete library of 9 role-specific Hermes agent configurations: sales, marketing, devops, support, finance, HR, research, legal, and executive. Deploy in minutes with cron schedules and MCP connectors."
 category: Agents
 tags:

--- a/hermes/agents/legal-agent.md
+++ b/hermes/agents/legal-agent.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Legal Agent  --  Contract Review & Compliance Automation
+title: "Hermes Legal Agent"
 description: Deploy an AI legal operations agent for contract review, regulatory monitoring, policy enforcement, audit preparation, and document management. Complete Hermes configuration blueprint.
 category: Agents
 tags:

--- a/hermes/agents/marketing-agent.md
+++ b/hermes/agents/marketing-agent.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Marketing Agent  --  Autonomous SEO, Campaign & Content Operations
+title: "Hermes Marketing Agent"
 description: Deploy an AI marketing agent for SEO monitoring, campaign analytics, content performance, competitive intelligence, and social scheduling. Complete Hermes blueprint with cron and connectors.
 category: Agents
 tags:

--- a/hermes/agents/research-agent.md
+++ b/hermes/agents/research-agent.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Research Agent  --  Market Intelligence & Competitive Analysis
+title: "Hermes Research Agent"
 description: Deploy an AI research agent for competitor monitoring, market intelligence, academic literature reviews, patent tracking, and news aggregation. Complete Hermes configuration blueprint.
 category: Agents
 tags:

--- a/hermes/agents/sales-agent.md
+++ b/hermes/agents/sales-agent.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Sales Agent Configuration  --  AI-Powered Pipeline & Outreach
+title: "Hermes Sales Agent Configuration"
 description: Deploy an autonomous Hermes sales agent for lead qualification, pipeline management, outreach sequences, and daily CRM reporting. Complete configuration blueprint with cron schedules.
 category: Agents
 tags:

--- a/hermes/agents/support-agent.md
+++ b/hermes/agents/support-agent.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Support Agent  --  Customer Ticket Triage & SLA Automation
+title: "Hermes Support Agent"
 description: Deploy an AI customer support agent for ticket triage, knowledge base search, response drafting, SLA monitoring, and trending issue detection. Complete Hermes configuration blueprint.
 category: Agents
 tags:

--- a/hermes/best-practices/cron-design.md
+++ b/hermes/best-practices/cron-design.md
@@ -1,5 +1,5 @@
 ---
-title: Cron Design Best Practices for Hermes Agent  --  Reliable Scheduled Automation
+title: "Cron Design Best Practices for Hermes Agent"
 description: Production-grade cron design for Hermes Agent scheduled automation. Idempotency, error handling with retry/backoff, rate limiting, monitoring, delivery targets, and anti-patterns. Build crons that don't fail silently.
 category: best-practices
 tags: [hermes-agent, cron-design, scheduled-automation, idempotency, error-handling, monitoring, rate-limiting]

--- a/hermes/best-practices/index.md
+++ b/hermes/best-practices/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Agent Best Practices Guide  --  Build Reliable AI Automation
+title: "Hermes Agent Best Practices Guide"
 description: Hermes Agent best practices for production AI automation. Anti-patterns, maturity model, cron design, model selection, memory management, security, skill development, and MCP server design. Community-driven reliability patterns.
 category: best-practices
 tags: [hermes-agent, best-practices, ai-automation, maturity-model, anti-patterns, production, reliability]

--- a/hermes/best-practices/mcp-design.md
+++ b/hermes/best-practices/mcp-design.md
@@ -1,5 +1,5 @@
 ---
-title: MCP Server Design Guide for Hermes Agent  --  Build Custom AI Tools
+title: "MCP Server Design Guide for Hermes Agent"
 description: MCP server design best practices for Hermes Agent. Tool design principles, error handling, pagination, performance, testing, and server lifecycle. Build production-ready Model Context Protocol servers for AI agent tools.
 category: best-practices
 tags: [hermes-agent, mcp-design, mcp-server, tool-design, model-context-protocol, error-handling, testing]

--- a/hermes/best-practices/memory-management.md
+++ b/hermes/best-practices/memory-management.md
@@ -1,5 +1,5 @@
 ---
-title: Memory Management Best Practices for Hermes Agent  --  Persistent AI Context
+title: "Memory Management Best Practices for Hermes Agent"
 description: Hermes Agent memory management guide. Honcho peer memory, GBrain organizational knowledge, memcore-cloud cross-session recall, GraphRAG, and Session DB. When to use each memory tier, compaction strategies, and anti-patterns.
 category: best-practices
 tags: [hermes-agent, memory-management, honcho, gbrain, memcore-cloud, context-optimization, persistent-memory, graphrag]

--- a/hermes/best-practices/model-selection.md
+++ b/hermes/best-practices/model-selection.md
@@ -1,5 +1,5 @@
 ---
-title: Model Selection Guide for Hermes Agent  --  Choose the Right AI Model
+title: "Model Selection Guide for Hermes Agent"
 description: Hermes Agent model selection best practices. Task-to-model mapping, cost optimization, local vs cloud tradeoffs, fallback chains, and decision tree. Save latency and cost with tiered model routing for every task type.
 category: best-practices
 tags: [hermes-agent, model-selection, ai-models, cost-optimization, ollama, openrouter, local-models, cloud-models]

--- a/hermes/best-practices/security.md
+++ b/hermes/best-practices/security.md
@@ -1,5 +1,5 @@
 ---
-title: Security Best Practices for Hermes Agent  --  Credentials, Approval Gates & Audit
+title: "Security Best Practices for Hermes Agent"
 description: Hermes Agent security best practices. Token and credential management, least-privilege access, tiered approval gates, audit logging, secrets management, plugin verification, and operational security checklist.
 category: best-practices
 tags: [hermes-agent, security, credentials, approval-gates, audit-logging, least-privilege, token-management, secrets]

--- a/hermes/best-practices/skill-development.md
+++ b/hermes/best-practices/skill-development.md
@@ -1,5 +1,5 @@
 ---
-title: Skill Development Guide for Hermes Agent  --  Build Reusable AI Skills
+title: "Skill Development Guide for Hermes Agent"
 description: Complete Hermes Agent skill development guide. SKILL.md anatomy, trigger patterns, verification steps, error recovery, testing methodology, lifecycle management, and publishing. Create production-ready reusable AI agent skills.
 category: best-practices
 tags: [hermes-agent, skill-development, skills, reusable-workflows, testing, triggers, error-handling, publishing]

--- a/hermes/blueprints/content-pipeline.md
+++ b/hermes/blueprints/content-pipeline.md
@@ -1,5 +1,5 @@
 ---
-title: Content Pipeline Blueprint for Hermes Agent  --  Automated Content Production
+title: "Content Pipeline Blueprint for Hermes Agent"
 description: End-to-end Hermes Agent content pipeline blueprint. Research, ideation, drafting, review, publication, and promotion  --  all orchestrated with cron-driven workflows, SEO analysis, and human editorial gates.
 category: blueprints
 tags: [hermes-agent, blueprint, content-pipeline, content-production, seo, editorial-workflow, publishing]

--- a/hermes/blueprints/customer-lifecycle.md
+++ b/hermes/blueprints/customer-lifecycle.md
@@ -1,5 +1,5 @@
 ---
-title: Customer Lifecycle Automation Blueprint  --  Onboarding to Win-Back with Hermes Agent
+title: "Customer Lifecycle Automation Blueprint"
 description: Multi-stage Hermes Agent customer lifecycle blueprint. Automate onboarding, engagement monitoring, churn detection, retention campaigns, and win-back. CRM, email marketing, and analytics orchestrated through cron-driven workflows.
 category: blueprints
 tags: [hermes-agent, blueprint, customer-lifecycle, onboarding, retention, churn-prevention, crm-automation]

--- a/hermes/blueprints/daily-ops.md
+++ b/hermes/blueprints/daily-ops.md
@@ -1,5 +1,5 @@
 ---
-title: Daily Operations Blueprint for Hermes Agent  --  Automate Your Business Day
+title: "Daily Operations Blueprint for Hermes Agent"
 description: End-to-end Hermes Agent daily operations blueprint. Morning briefing, task triage, midday pulse check, execution monitoring, and evening wrap-up. 12 cron jobs orchestrate a complete business day with human decision gates.
 category: blueprints
 tags: [hermes-agent, blueprint, daily-operations, morning-briefing, task-triage, cron, workflow-automation]

--- a/hermes/blueprints/financial-close.md
+++ b/hermes/blueprints/financial-close.md
@@ -1,5 +1,5 @@
 ---
-title: Financial Close Blueprint for Hermes Agent  --  Monthly Reconciliation Automation
+title: "Financial Close Blueprint for Hermes Agent"
 description: Monthly financial close automation blueprint for Hermes Agent. Data pull, account reconciliation, variance analysis, reporting, and forecasting  --  connected to QuickBooks, Stripe, banking data. Cron-driven with human sign-off gates.
 category: blueprints
 tags: [hermes-agent, blueprint, financial-close, reconciliation, accounting, quickbooks, stripe, monthly-reporting]

--- a/hermes/blueprints/incident-response.md
+++ b/hermes/blueprints/incident-response.md
@@ -1,5 +1,5 @@
 ---
-title: Incident Response Blueprint for Hermes Agent  --  Automated Detection & Remediation
+title: "Incident Response Blueprint for Hermes Agent"
 description: SLA-driven Hermes Agent incident response blueprint. Automated detection, triage, severity scoring, remediation coordination, and postmortem generation. Connects monitoring, communication, and issue tracking with time-gated escalation.
 category: blueprints
 tags: [hermes-agent, blueprint, incident-response, monitoring, sla, triage, remediation, postmortem, devops]

--- a/hermes/blueprints/index.md
+++ b/hermes/blueprints/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Agent Automation Blueprints  --  End-to-End AI Workflow Templates
+title: "Hermes Agent Automation Blueprints"
 description: Production-ready Hermes Agent automation blueprints for daily operations, customer lifecycle, content pipeline, financial close, and incident response. Cron-anchored workflows with human decision gates.
 category: blueprints
 tags: [hermes-agent, blueprints, automation, workflows, cron, daily-operations, customer-lifecycle, content-pipeline, financial-close, incident-response]

--- a/hermes/contributors/index.md
+++ b/hermes/contributors/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Contributors  --  How to Submit to the Hermes Ecosystem Directory
+title: "Hermes Contributors"
 description: Learn how to contribute to the largest Hermes Agent resource directory. Submit repos, review pending additions, and join the community of contributors. 448 repos indexed.
 category: Community
 tags:

--- a/hermes/integrations/crm-analytics.md
+++ b/hermes/integrations/crm-analytics.md
@@ -1,5 +1,5 @@
 ---
-title: CRM + Analytics Integration for Hermes Agent  --  Lead Scoring & Pipeline Forecasting
+title: "CRM + Analytics Integration for Hermes Agent"
 description: Connect CRM (HubSpot, Salesforce, Close) with analytics (GA4, PostHog) in Hermes Agent. Automated lead scoring, pipeline forecasting, marketing attribution with MCP server setup and cron-driven reporting patterns.
 category: integrations
 tags: [hermes-agent, integration, crm, analytics, hubspot, ga4, lead-scoring, pipeline-forecasting, attribution]

--- a/hermes/integrations/database-reporting.md
+++ b/hermes/integrations/database-reporting.md
@@ -1,5 +1,5 @@
 ---
-title: Database + Reporting Integration for Hermes Agent  --  Automated Queries & Dashboards
+title: "Database + Reporting Integration for Hermes Agent"
 description: Connect databases (PostgreSQL, MySQL, SQL Server, MongoDB) to Hermes Agent for automated reporting. Scheduled queries, dashboard generation, anomaly detection, and report distribution with MCP setup and cron patterns.
 category: integrations
 tags: [hermes-agent, integration, database, reporting, postgresql, mysql, mongodb, dashboards, anomaly-detection, cron]

--- a/hermes/integrations/email-calendar.md
+++ b/hermes/integrations/email-calendar.md
@@ -1,5 +1,5 @@
 ---
-title: Email + Calendar Integration for Hermes Agent  --  Automated Scheduling & Follow-ups
+title: "Email + Calendar Integration for Hermes Agent"
 description: Connect Gmail, Outlook, Google Calendar, and Outlook Calendar to Hermes Agent. Automate meeting scheduling, follow-up workflows, availability management with MCP servers and cron-driven automation patterns.
 category: integrations
 tags: [hermes-agent, integration, email, calendar, gmail, outlook, meeting-scheduling, follow-up-automation, mcp]

--- a/hermes/integrations/index.md
+++ b/hermes/integrations/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Agent Integration Examples  --  Connect Slack, GitHub, Email, CRM & Databases
+title: "Hermes Agent Integration Examples"
 description: Practical Hermes Agent integration guides connecting Slack, GitHub, email, calendar, CRM, analytics, databases, and reporting tools. MCP server setup, cron patterns, and automation workflows with detailed architecture.
 category: integrations
 tags: [hermes-agent, integrations, slack, github, email, calendar, crm, analytics, database, mcp-server, automation]

--- a/hermes/integrations/slack-github.md
+++ b/hermes/integrations/slack-github.md
@@ -1,5 +1,5 @@
 ---
-title: Slack + GitHub Integration for Hermes Agent  --  Automated Dev Workflow Notifications
+title: "Slack + GitHub Integration for Hermes Agent"
 description: Connect Slack and GitHub to Hermes Agent for automated PR notifications, issue triage, deployment status alerts, and daily standup digests. MCP server setup, webhook configuration, and cron patterns for development teams.
 category: integrations
 tags: [hermes-agent, integration, slack, github, pr-notifications, issue-tracking, deployment, devops, webhooks]

--- a/hermes/knowledge/index.md
+++ b/hermes/knowledge/index.md
@@ -1,5 +1,5 @@
 ---
-title: Memory Architecture Guide for Hermes Agent  --  Triple-Stack Persistent AI Memory
+title: "Memory Architecture Guide for Hermes Agent"
 description: "Hermes Agent memory architecture guide covering the triple stack: Honcho peer memory, GBrain organizational knowledge, memcore-cloud cross-session recall, GraphRAG, and Session DB. Production-tested persistent AI agent memory."
 category: knowledge
 tags: [hermes-agent, memory, honcho, gbrain, memcore-cloud, graphrag, persistent-memory, knowledge-management]

--- a/hermes/mcp/index.md
+++ b/hermes/mcp/index.md
@@ -1,5 +1,5 @@
 ---
-title: MCP Integration Guide for Hermes Agent  --  Connect 37+ Business Platforms
+title: "MCP Integration Guide for Hermes Agent"
 description: Complete Hermes Agent MCP integration guide. Connect 37+ business platforms through one CorpusIQ OAuth flow. CRM, email, analytics, advertising, databases, ecommerce, payments. Custom MCP server development and cross-source analysis.
 category: mcp
 tags: [hermes-agent, mcp, model-context-protocol, integration, corpusiq, crm, analytics, email, database, cross-source]

--- a/hermes/mcp/servers/external/ai-visibility-analytics.md
+++ b/hermes/mcp/servers/external/ai-visibility-analytics.md
@@ -1,5 +1,5 @@
 ---
-title: "AI Visibility Analytics MCP — Brand Monitoring Across AI Search Engines"
+title: "AI Visibility Analytics MCP — Brand Monitoring"
 description: "Monitor brand visibility across 15+ AI providers (ChatGPT, Perplexity, Gemini, AI Overviews). MCP connector for competitive intelligence and AI search tracking."
 category: mcp
 tags: [mcp-server, marketing, seo, brand-monitoring, ai-search, competitive-intelligence]

--- a/hermes/mcp/servers/external/appsigma-app-store-data-mcp.md
+++ b/hermes/mcp/servers/external/appsigma-app-store-data-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "AppSigma App Store Data MCP — ASO & App Analytics for AI Agents"
+title: "AppSigma App Store Data MCP — ASO & App Analytics"
 description: "Full public App Store search results as users see them — rankings, reviews, ASO keywords, sponsored slots, charts, and app analytics from any MCP client."
 category: mcp
 tags: [mcp-server, app-store, aso, ios, app-analytics, keyword-research, app-marketing]

--- a/hermes/mcp/servers/external/billingserv.md
+++ b/hermes/mcp/servers/external/billingserv.md
@@ -1,5 +1,5 @@
 ---
-title: "BillingServ MCP — Invoice & Customer Management for AI Agents"
+title: "BillingServ MCP — Invoice & Customer Management"
 description: "Connect AI agents to BillingServ API for customer, invoice, and order lookups. Automate billing inquiries and account reconciliation directly from your MCP client."
 category: mcp
 tags: [mcp-server, billing, invoicing, finance, accounts-receivable]

--- a/hermes/mcp/servers/external/booyah-index.md
+++ b/hermes/mcp/servers/external/booyah-index.md
@@ -1,5 +1,5 @@
 ---
-title: "Booyah Index MCP — Southeast Asia Business Directory for AI Agents"
+title: "Booyah Index MCP — Southeast Asia Business Directory"
 description: "Free AI-readable directory of 3,520 local businesses across 14 Southeast Asian cities. Search restaurants, services, and local businesses in Bangkok, Singapore, Bali, Kuala Lumpur, and more from any MCP client."
 category: mcp
 tags: [mcp-server, business-directory, southeast-asia, local-business, travel, market-research]

--- a/hermes/mcp/servers/external/coding-agent-pm-mcp.md
+++ b/hermes/mcp/servers/external/coding-agent-pm-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "Coding Agent Project Management MCP — 71 Tools for AI-Driven Development"
+title: "Coding Agent Project Management MCP — 71 Tools"
 description: "Project management for coding agents — bugs, features, sprints, cross-tenant contracts. 71 MCP tools for operators managing AI-assisted development workflows."
 category: mcp
 tags: [mcp-server, operations, project-management, development, coding-agents, agile]

--- a/hermes/mcp/servers/external/container-tracking-mcp.md
+++ b/hermes/mcp/servers/external/container-tracking-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "Container Tracking MCP — Ocean Freight Visibility for AI Agents"
+title: "Container Tracking MCP — Ocean Freight Visibility"
 description: "Track ocean containers across 200+ shipping lines by container number, bill of lading, or booking reference. Live milestones, vessel positions, and supply chain visibility from any MCP client."
 category: mcp
 tags: [mcp-server, logistics, shipping, supply-chain, container-tracking, ocean-freight]

--- a/hermes/mcp/servers/external/elasticsearch-mcp/index.md
+++ b/hermes/mcp/servers/external/elasticsearch-mcp/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Elasticsearch MCP — Full-Text Search & Observability for AI Agents"
+title: "Elasticsearch MCP — Full-Text Search & Observability"
 description: "Connect AI agents to Elasticsearch via the official Elastic MCP server. Full-text search, vector search, aggregations, and observability."
 category: mcp
 tags: [mcp-server]

--- a/hermes/mcp/servers/external/eleata-einvoice.md
+++ b/hermes/mcp/servers/external/eleata-einvoice.md
@@ -1,5 +1,5 @@
 ---
-title: "Integration Guide: Eleata E-Invoice MCP — EU E-Invoice Validation for AI Agents"
+title: "Eleata E-Invoice MCP — EU E-Invoice Validation"
 description: "Connect AI agents to Eleata E-Invoice MCP for Peppol, XRechnung, Factur-X, and UBL/CII validation. Automate EU e-invoicing compliance."
 category: mcp
 tags: [mcp, einvoice, eu-compliance, peppol, xrechnung, factur-x, ubl, electa]

--- a/hermes/mcp/servers/external/google-maps-email-extractor.md
+++ b/hermes/mcp/servers/external/google-maps-email-extractor.md
@@ -1,5 +1,5 @@
 ---
-title: "Google Maps Email Extractor — Maps-to-Leads Pipeline for AI Agents"
+title: "Google Maps Email Extractor — Maps-to-Leads Pipeline"
 description: "Search businesses on Google Maps and extract verified contact emails for outreach. Turn any Google Maps search into a qualified lead list with verified email addresses — directly from AI agents."
 category: mcp
 tags: [mcp-server, lead-generation, google-maps, email-extraction, sales, outreach, prospecting, business-intelligence]

--- a/hermes/mcp/servers/external/hermesplant-mcp-server.md
+++ b/hermes/mcp/servers/external/hermesplant-mcp-server.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Plant MCP Server — Deterministic Finance & Quant APIs Integration Guide"
+title: "Hermes Plant MCP Server — Deterministic Finance & Quant APIs"
 description: "Connect AI agents to provably correct financial calculations, quantitative models, and market analytics via the Hermes Plant MCP server. Paid over x402 with cryptographic payment rails."
 ---
 

--- a/hermes/mcp/servers/external/kubernetes-mcp-server/index.md
+++ b/hermes/mcp/servers/external/kubernetes-mcp-server/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Kubernetes MCP Server — Manage Clusters, Pods, Deployments via MCP"
+title: "Kubernetes MCP Server — Manage Clusters, Pods, Deployments"
 description: "Integration guide for Manusa/kubernetes-mcp-server. MCP server for Kubernetes and OpenShift — native binary, npm, Python, or Docker. 1,814 stars."
 category: mcp
 tags: [mcp-server, kubernetes, devops, cloud, infrastructure, hermes-agent]

--- a/hermes/mcp/servers/external/lawstronaut-mcp.md
+++ b/hermes/mcp/servers/external/lawstronaut-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "Lawstronaut MCP — Global Legal & Regulatory Document Access for AI Agents"
+title: "Lawstronaut MCP — Global Legal & Regulatory Document Access"
 description: "Connect Lawstronaut to Hermes Agent. Access millions of official legal and regulatory source documents from 155+ jurisdictions — structured legal research, laws, regulations, cases, and guidance."
 category: mcp
 tags: [mcp-server, legal, compliance, regulatory, lawstronaut, legal-research]

--- a/hermes/mcp/servers/external/llm-observability-mcp.md
+++ b/hermes/mcp/servers/external/llm-observability-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "LLM Observability MCP (LangTrace) — Open Source Monitoring for AI Agents"
+title: "LLM Observability MCP (LangTrace) — Open Source Monitoring"
 description: "Open source LLM observability proxy. Drop-in for OpenAI, Anthropic, Gemini with request logging, cost tracking, and agent tracing. Self-host with Docker. MIT."
 category: mcp
 tags: [mcp-server, devops, llm, observability, monitoring, cost-tracking, agent-tracing]

--- a/hermes/mcp/servers/external/meta-business-mcp.md
+++ b/hermes/mcp/servers/external/meta-business-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "Meta Business MCP — WhatsApp Business Cloud API Integration Guide"
+title: "Meta Business MCP — WhatsApp Business Cloud API"
 description: "Connect AI agents to WhatsApp Business Cloud API via MCP — 24 tools for message orchestration, compliance engine, and error intelligence. Production-validated for WhatsApp-first markets."
 ---
 

--- a/hermes/mcp/servers/external/nothumansearch.md
+++ b/hermes/mcp/servers/external/nothumansearch.md
@@ -1,5 +1,5 @@
 ---
-title: "Integration Guide: NotHumanSearch — AI Agent Search Engine for Operator Visibility"
+title: "NotHumanSearch — AI Agent Search Engine"
 description: "Connect NotHumanSearch MCP to understand how AI agents discover and rank your business. Optimize for agentic search visibility."
 category: mcp
 tags: [mcp, geo, ai-search, agentic-seo, nothumansearch, visibility]

--- a/hermes/mcp/servers/external/periscope-mcp.md
+++ b/hermes/mcp/servers/external/periscope-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "Periscope MCP — Playwright-Powered Website Testing for AI Agents"
+title: "Periscope MCP — Playwright-Powered Website Testing"
 description: "63 Playwright-powered testing tools with agent-first ergonomics. Browser automation, screenshots, visual regression, accessibility checks, and assertions — all from AI agents. Built for CI/CD integration."
 category: mcp
 tags: [mcp-server, testing, playwright, browser-automation, qa, web-testing, ci-cd, developer-tools]

--- a/hermes/mcp/servers/external/podcast-sponsorship-mcp.md
+++ b/hermes/mcp/servers/external/podcast-sponsorship-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "Podcast Sponsorship Discovery MCP — Lead Generation from 4M+ Sponsorships"
+title: "Podcast Sponsorship Discovery MCP — Lead Generation"
 description: "Find brands that sponsor podcasts like yours. Reveal the buyer by name and email from 4M+ podcast sponsorships. Updated daily. Lead gen for operators."
 category: mcp
 tags: [mcp-server, marketing, sales, lead-generation, podcast, sponsorship, outreach]

--- a/hermes/mcp/servers/external/saas-pricing-mcp.md
+++ b/hermes/mcp/servers/external/saas-pricing-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "SaaS & AI Pricing API MCP — Competitive Intelligence for 490+ Tools"
+title: "SaaS & AI Pricing API MCP — Competitive Intelligence"
 description: "Free REST API and MCP server for verified SaaS, AI, and LLM pricing across 490+ tools. OpenAPI 3.1, no API key required. Market research for operators."
 category: mcp
 tags: [mcp-server, business-intelligence, saas, pricing, competitive-research, market-intelligence]

--- a/hermes/mcp/servers/external/seoforgpt.md
+++ b/hermes/mcp/servers/external/seoforgpt.md
@@ -1,5 +1,5 @@
 ---
-title: "SEOforGPT MCP — AI Visibility & Generative Engine Optimization"
+title: "SEOforGPT MCP — AI Visibility & Engine Optimization"
 description: "Connect SEOforGPT to Hermes Agent. Audit AI visibility across ChatGPT, Claude, Perplexity, Gemini. Track competitors, generate AI-optimized content, publish to CMS."
 category: mcp
 tags: [mcp-server, seo, geo, ai-visibility, marketing, content-generation, competitor-tracking]

--- a/hermes/mcp/servers/external/unstructured-transform-mcp.md
+++ b/hermes/mcp/servers/external/unstructured-transform-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "Transform MCP (Unstructured) — Document Parsing for AI Agents"
+title: "Transform MCP (Unstructured) — Document Parsing"
 description: "Connect Unstructured Transform MCP to Hermes Agent. Parse PDFs, CSVs, images, and documents into structured AI-ready data — turns raw files into queryable intelligence."
 category: mcp
 tags: [mcp-server, document-processing, unstructured, pdf-parsing, data-extraction]

--- a/hermes/mcp/servers/external/webotee-amazon-mcp.md
+++ b/hermes/mcp/servers/external/webotee-amazon-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "Webotee Amazon MCP — Amazon Seller Intelligence for AI Agents"
+title: "Webotee Amazon MCP — Amazon Seller Intelligence"
 description: "Connect Webotee Amazon MCP to Hermes Agent. Research Amazon products, analyze buy-box history, identify competing sellers, and discover under-competed niches. Built for Amazon sellers and ecommerce operators."
 category: mcp
 tags: [mcp-server, webotee, amazon, ecommerce, seller-intelligence, product-research, niche-analysis]

--- a/hermes/outputs/by-company-size/enterprise.md
+++ b/hermes/outputs/by-company-size/enterprise.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent for Enterprise | AI Automation Security, Scale & Governance"
+title: "Hermes Agent for Enterprise"
 description: "Deploy Hermes Agent AI automation at enterprise scale with SOC 2 compliance, multi-region data residency, segregation of duties, and immutable audit logging."
 category: "Company Size"
 tags:

--- a/hermes/outputs/by-company-size/mid-market.md
+++ b/hermes/outputs/by-company-size/mid-market.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent for Mid-Market | Multi-Team AI Automation & Orchestration"
+title: "Hermes Agent for Mid-Market"
 description: "Deploy cross-department AI automation for mid-market companies (50-500 employees). Marketing, sales, finance, and CS profiles with approval workflows and shared infrastructure."
 category: "Company Size"
 tags:

--- a/hermes/outputs/by-company-size/startup.md
+++ b/hermes/outputs/by-company-size/startup.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent for Startups | AI Automation to Do More With Less"
+title: "Hermes Agent for Startups"
 description: "Get 5-10 hours back per week with Hermes Agent AI automation for startups. Customer onboarding, daily metrics, payment recovery, and market monitoring  --  running in under an hour."
 category: "Company Size"
 tags:

--- a/hermes/outputs/case-studies/compliance-audit.md
+++ b/hermes/outputs/case-studies/compliance-audit.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Compliance & Audit Automation | Continuous SOC 2 HIPAA GDPR Monitoring"
+title: "Hermes Agent Compliance & Audit Automation"
 description: "Automate SOC 2, HIPAA, and GDPR compliance with Hermes Agent. Continuous evidence collection, audit trails, and regulatory reporting using cron-driven AI skills."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/customer-support.md
+++ b/hermes/outputs/case-studies/customer-support.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Customer Support Automation | Ticket Triage & SLA Management AI"
+title: "Hermes Agent Customer Support Automation"
 description: "Automate multi-channel ticket triage, knowledge base search, SLA monitoring, escalation routing, and customer health tracking with Hermes Agent AI."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/ecommerce.md
+++ b/hermes/outputs/case-studies/ecommerce.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Ecommerce Automation | Multi-Channel Operations & Cart Recovery"
+title: "Hermes Agent Ecommerce Automation"
 description: "Automate inventory synchronization, order processing, abandoned cart recovery, and multi-channel listing management with Hermes Agent AI for ecommerce."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/education.md
+++ b/hermes/outputs/case-studies/education.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Education Automation | Course Materials & Student Progress AI"
+title: "Hermes Agent Education Automation"
 description: "Automate course material generation, student progress tracking, assignment grading assistance, and research workflows with Hermes Agent AI for education."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/financial-services.md
+++ b/hermes/outputs/case-studies/financial-services.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Financial Services Automation | Portfolio Monitoring & Reconciliation"
+title: "Hermes Agent Financial Services Automation"
 description: "Automate portfolio monitoring, transaction reconciliation, fraud detection, and regulatory filing with Hermes Agent AI workflows for financial services firms."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/government.md
+++ b/hermes/outputs/case-studies/government.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Government Automation | FOIA Processing & Public Records AI"
+title: "Hermes Agent Government Automation"
 description: "Automate FOIA request processing, document management, constituent services, and compliance reporting with Hermes Agent AI workflows for government agencies."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/healthcare.md
+++ b/hermes/outputs/case-studies/healthcare.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Healthcare Automation | HIPAA-Compliant AI Workflows for Medical Practices"
+title: "Hermes Agent Healthcare Automation"
 description: "Automate patient record management, appointment scheduling, insurance verification, and lab notifications with HIPAA-compliant Hermes Agent AI workflows for healthcare."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/legal-firms.md
+++ b/hermes/outputs/case-studies/legal-firms.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Legal Automation | Case Research & Document Review AI for Law Firms"
+title: "Hermes Agent Legal Automation"
 description: "Automate case research, document review, billing compliance, deadline tracking, and conflict checking with Hermes Agent AI workflows for legal firms."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/manufacturing.md
+++ b/hermes/outputs/case-studies/manufacturing.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Manufacturing Automation | Supply Chain & Quality Control AI"
+title: "Hermes Agent Manufacturing Automation"
 description: "Automate supply chain monitoring, quality control alerts, and equipment maintenance with Hermes Agent AI workflows for manufacturing operations."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/nonprofit.md
+++ b/hermes/outputs/case-studies/nonprofit.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Nonprofit Automation | Donor Management & Grant Tracking AI"
+title: "Hermes Agent Nonprofit Automation"
 description: "Automate donor management, grant tracking, volunteer coordination, and impact reporting with Hermes Agent AI workflows for nonprofit organizations."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/professional-services.md
+++ b/hermes/outputs/case-studies/professional-services.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Professional Services Automation | Agency & Consulting AI Workflows"
+title: "Hermes Agent Professional Services Automation"
 description: "Automate client onboarding, time tracking, invoice generation, and project status reporting with Hermes Agent AI workflows for agencies and consultancies."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/real-estate.md
+++ b/hermes/outputs/case-studies/real-estate.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Real Estate Automation | Listing Management & Lead Routing AI"
+title: "Hermes Agent Real Estate Automation"
 description: "Automate property listing syndication, lead qualification, showing coordination, and transaction management with Hermes Agent AI workflows for real estate."
 category: "Case Study"
 tags:

--- a/hermes/outputs/case-studies/revenue-operations.md
+++ b/hermes/outputs/case-studies/revenue-operations.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Agent Revenue Operations Automation | Pipeline Forecasting & Reconciliation"
+title: "Hermes Agent Revenue Operations Automation"
 description: "Automate pipeline hygiene, sales forecasting, commission calculation, and cross-source revenue reconciliation with Hermes Agent AI for RevOps teams."
 category: "Case Study"
 tags:

--- a/hermes/outputs/index.md
+++ b/hermes/outputs/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Agent Outputs  --  Real-World Implementation Guides & Case Studies
+title: "Hermes Agent Outputs"
 description: "Field manual of Hermes Agent implementations: industry case studies, company-size guides, and copy-paste cron templates. Real automations for compliance, healthcare, finance, manufacturing, and more."
 category: Outputs
 tags:

--- a/hermes/outputs/workflows/templates.md
+++ b/hermes/outputs/workflows/templates.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Cron Templates  --  12 Copy-Paste Workflows for Autonomous Agents
+title: "Hermes Cron Templates"
 description: "Ready-to-deploy cron templates for Hermes Agent: email triage, report generation, data sync, anomaly detection, SLA monitoring, and more. Copy, adapt, deploy in minutes."
 category: Outputs
 tags:

--- a/hermes/prompts/business-operations.md
+++ b/hermes/prompts/business-operations.md
@@ -1,5 +1,5 @@
 ---
-title: Business Operations Prompts for Hermes Agent  --  Email, Meetings & Project Planning
+title: "Business Operations Prompts for Hermes Agent"
 description: Hermes Agent business operations prompts for email communication, meeting management, project planning, and task organization. Replace bracketed text with your team context, tools, and workflow preferences.
 category: prompts
 tags: [hermes-agent, prompts, business-operations, email, meetings, project-planning, task-management, workflow]

--- a/hermes/prompts/code-generation.md
+++ b/hermes/prompts/code-generation.md
@@ -1,5 +1,5 @@
 ---
-title: Code Generation Prompts for Hermes Agent  --  AI-Powered Development Templates
+title: "Code Generation Prompts for Hermes Agent"
 description: Curated Hermes Agent code generation prompts for writing, refactoring, debugging, and reviewing code. Prompt templates with placeholders for Python, JavaScript, SQL, and more. Model selection guide for code tasks.
 category: prompts
 tags: [hermes-agent, prompts, code-generation, debugging, refactoring, python, javascript, sql, ai-coding]

--- a/hermes/prompts/content-creation.md
+++ b/hermes/prompts/content-creation.md
@@ -1,5 +1,5 @@
 ---
-title: Content Creation Prompts for Hermes Agent  --  Blog, Social, Email & SEO Templates
+title: "Content Creation Prompts for Hermes Agent"
 description: Hermes Agent content creation prompts for blog posts, social media, email campaigns, video scripts, and SEO-optimized content. Replace bracketed placeholders with your brand voice, audience, and topic.
 category: prompts
 tags: [hermes-agent, prompts, content-creation, blog-posts, social-media, email-marketing, seo, video-scripts]

--- a/hermes/prompts/creative.md
+++ b/hermes/prompts/creative.md
@@ -1,5 +1,5 @@
 ---
-title: Creative Prompts for Hermes Agent  --  Brainstorming, Naming & Design Strategy
+title: "Creative Prompts for Hermes Agent"
 description: Hermes Agent creative prompts for brainstorming, naming, design briefs, creative strategy, and ideation. Replace bracketed text with your brand context, creative brief, and style preferences. Temperature optimization tips included.
 category: prompts
 tags: [hermes-agent, prompts, creative, brainstorming, naming, design, ideation, creative-strategy]

--- a/hermes/prompts/data-analysis.md
+++ b/hermes/prompts/data-analysis.md
@@ -1,5 +1,5 @@
 ---
-title: Data Analysis Prompts for Hermes Agent  --  SQL, Reporting & Visualization
+title: "Data Analysis Prompts for Hermes Agent"
 description: Hermes Agent data analysis prompts for SQL query generation, reporting, visualization guidance, and metric computation. Prompt templates with placeholders for your database schema, analytics tools, and business questions.
 category: prompts
 tags: [hermes-agent, prompts, data-analysis, sql, reporting, visualization, metrics, business-intelligence]

--- a/hermes/prompts/index.md
+++ b/hermes/prompts/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Agent Prompt Library  --  Curated AI Prompt Templates for Every Task
+title: "Hermes Agent Prompt Library"
 description: Curated Hermes Agent prompt templates for code generation, content creation, data analysis, business operations, research, and creative work. Customization guide, model selection, chaining strategies, and common pitfalls.
 category: prompts
 tags: [hermes-agent, prompts, prompt-templates, code-generation, content-creation, data-analysis, ai-prompts]

--- a/hermes/prompts/research.md
+++ b/hermes/prompts/research.md
@@ -1,5 +1,5 @@
 ---
-title: Research Prompts for Hermes Agent  --  Competitive Analysis & Market Intelligence
+title: "Research Prompts for Hermes Agent"
 description: Hermes Agent research prompts for competitive analysis, market sizing, technology evaluation, trend reports, and structured investigation. Replace bracketed text with your research parameters and data sources.
 category: prompts
 tags: [hermes-agent, prompts, research, competitive-analysis, market-sizing, technology-evaluation, trend-reports]

--- a/hermes/setup/cloud-vps.md
+++ b/hermes/setup/cloud-vps.md
@@ -1,5 +1,5 @@
 ---
-title: Cloud VPS Hermes Agent Setup  --  24/7 AI Agent for $5-20/month
+title: "Cloud VPS Hermes Agent Setup"
 description: Deploy Hermes Agent on a cloud VPS for always-on AI automation. Step-by-step setup for Hetzner, DigitalOcean, AWS, Vultr. API-based models, systemd persistence, security hardening. $5/month budget deployment.
 category: setup
 tags: [cloud-vps, hermes-agent, setup-guide, hetzner, digitalocean, openrouter, systemd, 24/7-automation]

--- a/hermes/setup/docker.md
+++ b/hermes/setup/docker.md
@@ -1,5 +1,5 @@
 ---
-title: Docker Hermes Agent Setup  --  Reproducible Container Deployment Guide
+title: "Docker Hermes Agent Setup"
 description: Deploy Hermes Agent as a Docker container for reproducible AI automation. Docker Compose setup with persistent volumes, MCP server integration, cron persistence, and production checklist. Works on any host.
 category: setup
 tags: [docker, hermes-agent, setup-guide, container, docker-compose, reproducible, cicd, deployment]

--- a/hermes/setup/gaming-pc.md
+++ b/hermes/setup/gaming-pc.md
@@ -1,5 +1,5 @@
 ---
-title: Gaming PC Hermes Agent Setup  --  CUDA-Accelerated AI Workstation
+title: "Gaming PC Hermes Agent Setup"
 description: Run Hermes Agent on your gaming PC with NVIDIA CUDA acceleration. Local LLM inference at 50-200 tokens/sec, zero API costs. Step-by-step setup for Ubuntu Linux with Ollama, GPU optimization, and persistent operation.
 category: setup
 tags: [gaming-pc, hermes-agent, setup-guide, nvidia, cuda, ollama, gpu-acceleration, local-models]

--- a/hermes/setup/mac-mini-standalone.md
+++ b/hermes/setup/mac-mini-standalone.md
@@ -1,5 +1,5 @@
 ---
-title: Mac Mini M4 Hermes Agent Setup  --  Standalone AI Workstation Guide
+title: "Mac Mini M4 Hermes Agent Setup"
 description: Step-by-step Mac Mini M4 setup guide for Hermes Agent. Run local LLMs with Ollama/MLX, browser automation with Playwright, and persistent crons on a single silent machine. $599+ hardware, free local inference.
 category: setup
 tags: [mac-mini, hermes-agent, setup-guide, ollama, mlx, browser-automation, standalone, apple-silicon]

--- a/hermes/setup/raspberry-pi.md
+++ b/hermes/setup/raspberry-pi.md
@@ -1,5 +1,5 @@
 ---
-title: Raspberry Pi 5 Hermes Agent Setup  --  Ultra-Low-Cost 24/7 AI Agent
+title: "Raspberry Pi 5 Hermes Agent Setup"
 description: Run Hermes Agent on Raspberry Pi 5 for under $80 hardware and $5/month ongoing. Always-on email monitoring, cron jobs, and lightweight AI automation. Step-by-step Pi setup with cloud models and external storage.
 category: setup
 tags: [raspberry-pi, hermes-agent, setup-guide, low-cost, always-on, arm64, cron-automation, budget-ai]

--- a/hermes/setup/windows-wsl.md
+++ b/hermes/setup/windows-wsl.md
@@ -1,5 +1,5 @@
 ---
-title: Windows 11 WSL2 Hermes Agent Setup  --  Linux AI Agent on Windows
+title: "Windows 11 WSL2 Hermes Agent Setup"
 description: Run Hermes Agent on Windows 11 with full Linux compatibility via WSL2. GPU passthrough for NVIDIA CUDA, native Ollama models, systemd persistence, and browser automation. Free if you already own a Windows PC.
 category: setup
 tags: [windows, wsl2, hermes-agent, setup-guide, nvidia, gpu-passthrough, ollama, linux-on-windows]

--- a/hermes/skills/catalog/clawdirect-setup.md
+++ b/hermes/skills/catalog/clawdirect-setup.md
@@ -1,5 +1,5 @@
 ---
-title: "Setup Guide: napoleond/clawdirect — Agent Self-Direction Framework (9K+ Installs)"
+title: "napoleond/clawdirect — Agent Self-Direction Framework"
 description: "Complete setup guide for clawdirect and clawdirect-dev: structured agent task execution, work trees, directives, and development mode for Hermes/OpenClaw agents."
 ---
 

--- a/hermes/skills/catalog/clawdis-setup.md
+++ b/hermes/skills/catalog/clawdis-setup.md
@@ -1,5 +1,5 @@
 ---
-title: "Setup Guide: steipete/clawdis — 14 OpenClaw Skills (37K+ Installs)"
+title: "steipete/clawdis — 14 OpenClaw Skills"
 description: "Complete setup guide for the clawdis skill collection: tmux, openai-whisper, ordercli, peekaboo, himalaya, clawhub, video-frames, session-logs, healthcheck, trello, model-usage, sonoscli, blogwatcher, spotify-player."
 ---
 

--- a/hermes/skills/catalog/clawdstrike-setup.md
+++ b/hermes/skills/catalog/clawdstrike-setup.md
@@ -1,5 +1,5 @@
 ---
-title: "Setup Guide: cantinaxyz/clawdstrike — Agent Red-Team Security Testing (486 Installs)"
+title: "cantinaxyz/clawdstrike — Agent Red-Team Security Testing"
 description: "Complete setup guide for clawdstrike: automated vulnerability scanning and security testing for Hermes/OpenClaw agent deployments."
 ---
 

--- a/hermes/skills/catalog/distribute-skill-to-all-agents-setup.md
+++ b/hermes/skills/catalog/distribute-skill-to-all-agents-setup.md
@@ -1,5 +1,5 @@
 ---
-title: distribute-skill-to-all-agents — Full Setup Guide for Hermes Agents
+title: "distribute-skill-to-all-agents — Setup Guide"
 description: Install, configure, and use the distribute-skill-to-all-agents skill from davidondrej/skills. Sync a skill across Codex, Claude Code, Pi, and Hermes agent folders so all agents see it.
 ---
 

--- a/hermes/skills/catalog/impeccable-setup.md
+++ b/hermes/skills/catalog/impeccable-setup.md
@@ -1,5 +1,5 @@
 ---
-title: Impeccable Writing Framework — Full Setup Guide for Hermes Agents
+title: "Impeccable Writing Framework — Setup Guide"
 description: Install, configure, and use pbakaus/impeccable — an AI writing quality framework that teaches Hermes style rules, structure templates, and content arrangement. 90K combined installs.
 ---
 

--- a/hermes/skills/catalog/index.md
+++ b/hermes/skills/catalog/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Hermes Skills Catalog — Quality-Tiered Agent Skills Directory"
+title: "Hermes Skills Catalog — Quality-Tiered Directory"
 description: "Curated directory of community-validated Hermes agent skills. Quality tiers (Production/Beta/Community), starter pack, evaluation guide, and installation instructions. 445+ skills catalogued."
 ---
 

--- a/hermes/skills/catalog/matt-pocock-engineering-setup/index.md
+++ b/hermes/skills/catalog/matt-pocock-engineering-setup/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Matt Pocock Engineering Skills — Setup Guide for Hermes Agents"
+title: "Matt Pocock Engineering Skills — Setup Guide"
 description: "Install and configure the 5-skill Matt Pocock engineering suite: architecture review, PRD generation, issue decomposition, repo setup, and adversarial plan grilling. 1.3M+ combined installs."
 ---
 

--- a/hermes/skills/catalog/nemoclaw-user-guide-setup.md
+++ b/hermes/skills/catalog/nemoclaw-user-guide-setup.md
@@ -1,5 +1,5 @@
 ---
-title: NemoClaw User Guide — Security Setup for Hermes/OpenClaw Agents
+title: "NemoClaw User Guide — Security Setup"
 description: Install and use the NemoClaw security user guide from nvidia/skills (99 installs). Enterprise-grade security best practices for autonomous Hermes agent deployments.
 ---
 

--- a/hermes/skills/catalog/openclaw-secure-linux-cloud-setup.md
+++ b/hermes/skills/catalog/openclaw-secure-linux-cloud-setup.md
@@ -1,5 +1,5 @@
 ---
-title: OpenClaw Secure Linux Cloud — Full Setup Guide for Hermes Agents
+title: "OpenClaw Secure Linux Cloud — Setup Guide"
 description: Install and use xixu-me/skills openclaw-secure-linux-cloud — hardened Linux cloud deployment for OpenClaw/Hermes agents. 244K installs on skills.sh.
 ---
 

--- a/hermes/skills/catalog/safari-web-agent-setup.md
+++ b/hermes/skills/catalog/safari-web-agent-setup.md
@@ -1,5 +1,5 @@
 ---
-title: Safari Web Agent — Native macOS Browser Automation Setup Guide
+title: "Safari Web Agent — macOS Browser Automation Setup"
 description: Install and configure safari-web-agent for real Safari browser automation using native macOS CGEvent. Anti-bot bypass, login session persistence, works where Playwright fails. Hermes + Claude Code.
 ---
 

--- a/hermes/skills/catalog/skill-repo-manager-setup.md
+++ b/hermes/skills/catalog/skill-repo-manager-setup.md
@@ -1,5 +1,5 @@
 ---
-title: Skill Repo Manager — Hermes Skill Repository Management Setup Guide
+title: "Skill Repo Manager — Hermes Repository Setup Guide"
 description: Install and configure Victor-F-M-A-R/skywork-skill-skill-repo-manager — manage the complete lifecycle of Hermes skill GitHub repositories with sync, audit, and update detection
 ---
 

--- a/hermes/skills/creating-skills.md
+++ b/hermes/skills/creating-skills.md
@@ -1,5 +1,5 @@
 ---
-title: Creating Custom Skills for Hermes Agent  --  Complete Step-by-Step Guide
+title: "Creating Custom Skills for Hermes Agent"
 description: Complete guide to creating custom Hermes Agent skills. SKILL.md anatomy, trigger patterns, verification steps, error recovery, testing methodology, and publishing. Build reusable AI agent workflows step by step.
 category: skills
 tags: [hermes-agent, skills, custom-skills, skill-development, triggers, testing, publishing, reusable-workflows]

--- a/hermes/skills/marketplace/new-july1-2026/index.md
+++ b/hermes/skills/marketplace/new-july1-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 July 1, 2026 — Official Hermes Gap Sweep: 11 New Core Skills + Hermes Ecosystem Expansion (49 total)"
+title: "July 1, 2026 — Official Hermes Gap Sweep"
 description: "New Hermes skills discovered July 1, 2026: 11 official Hermes Agent skills, 23 Hermes ecosystem skills, 15 ClawSec security skills. First discovery of these core utilities missed in previous sweeps."
 ---
 

--- a/hermes/skills/marketplace/new-july2-2026/index.md
+++ b/hermes/skills/marketplace/new-july2-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 July 2, 2026 — Hermes Browser Extension + OpenClaw on Android"
+title: "July 2, 2026 — Hermes Browser Extension"
 description: "2 new Hermes-relevant skills discovered July 2, 2026: Hermes Browser Extension (439⭐) brings side-panel access to Chrome/Edge, OpenClaw Android (1,649⭐) runs agents on old phones."
 ---
 

--- a/hermes/skills/marketplace/new-july3-2026-update/index.md
+++ b/hermes/skills/marketplace/new-july3-2026-update/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 July 3, 2026 (Update) — Hermes Hybrid Memory + 5 More Skills"
+title: "July 3, 2026 (Update) — Hermes Hybrid Memory + 5 More Skills"
 description: "6 additional Hermes-relevant repos discovered in the late July 3 sweep: Hybrid Memory plugin (graph+vector+holographic), MCP ChatGPT bridge, Agent Bookmarks for Notion, MoA Synthesis decision discipline, BDH Graph Harness, and RedSeek Rescue."
 ---
 

--- a/hermes/skills/marketplace/new-july3-2026/index.md
+++ b/hermes/skills/marketplace/new-july3-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 July 3, 2026 — Hermex iPhone App + Crypto Radar + Agent Memory Stack"
+title: "July 3, 2026 — Hermex iPhone App"
 description: "7 new Hermes-relevant repos discovered July 3, 2026: Hermex native iPhone app (286⭐), Hermes Crypto Radar, Da7-Tech/mind memory engine, Obsidian plugin, n8n workflow engineer, Hermes skins, and Nick's Stack template."
 ---
 

--- a/hermes/skills/marketplace/new-july4-2026-update/index.md
+++ b/hermes/skills/marketplace/new-july4-2026-update/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 July 4, 2026 (Update) — hermes-top Dashboard + Neo Theme + Backup + AGEL-Comp Safety"
+title: "July 4, 2026 (Update) — hermes-top Dashboard"
 description: "5 new Hermes-relevant repos discovered in late July 4 sweep: hermes-top terminal dashboard (1⭐), Neo Desktop Theme (2⭐), Hermes Full Backup (1⭐), IC-sd Agent Skills (1⭐), AGEL-Comp Safety Framework."
 ---
 

--- a/hermes/skills/marketplace/new-july4-2026-update2/index.md
+++ b/hermes/skills/marketplace/new-july4-2026-update2/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 July 4, 2026 (Update 2) — Hermes Idea Workflow Suite + OpenClaw Tooling"
+title: "July 4, 2026 (Update 2) — Hermes Idea Workflow Suite"
 description: "6 new Hermes-relevant skills discovered in a July 4 late-evening sweep: akoliteza/hermes-agent-idea-workflow (4 skills, 235⭐), archieindian/openclaw-superpowers tool-description-optimizer, and heyvhuang/ship-faster tool-openclaw."
 ---
 

--- a/hermes/skills/marketplace/new-july4-2026/index.md
+++ b/hermes/skills/marketplace/new-july4-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 July 4, 2026 — agent-sessions (683⭐) + Hermes ArXiv Agent + 22 More"
+title: "July 4, 2026 — agent-sessions (683⭐)"
 description: "24 new Hermes-relevant repos discovered July 4, 2026: agent-sessions macOS session browser (683⭐), Hermes ArXiv Agent (91⭐), memoria-vault research OS, cinematic-scroll-skill (9⭐), Hermes Meshtastic adapter, and more."
 ---
 

--- a/hermes/skills/marketplace/new-june15-2026/index.md
+++ b/hermes/skills/marketplace/new-june15-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: June 15, 2026  --  Nous Research Hermes Agent Expansion (23 skills)
+title: "June 15, 2026 -- Nous Research Hermes Agent Expansion"
 description: Daily sweep found 23 unlisted nousresearch/hermes-agent skills with 131-158 installs each. Creative tools, macOS automation, dev workflows  --  all from the official repo.
 ---
 

--- a/hermes/skills/marketplace/new-june17-2026/index.md
+++ b/hermes/skills/marketplace/new-june17-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: New Skills  --  June 17, 2026 (nousresearch/hermes-agent expansion)
+title: "New Skills"
 description: 6 new Hermes Agent skills discovered June 17, 2026 from nousresearch/hermes-agent  --  native MCP client, office document generation, DuckDuckGo search, meme generation, vLLM serving, and Excel authoring.
 ---
 

--- a/hermes/skills/marketplace/new-june18-2026-ecosystem/index.md
+++ b/hermes/skills/marketplace/new-june18-2026-ecosystem/index.md
@@ -1,5 +1,5 @@
 ---
-title: New Skills  --  June 18, 2026 (Ecosystem Tools  --  Honcho + GBrain)
+title: "New Skills"
 description: 12 newly catalogued Hermes ecosystem skills from plastic-labs/honcho (memory/context) and garrytan/gbrain (agent brain operations)  --  essential infrastructure for production Hermes agents.
 ---
 

--- a/hermes/skills/marketplace/new-june18-2026-final-sweep/index.md
+++ b/hermes/skills/marketplace/new-june18-2026-final-sweep/index.md
@@ -1,5 +1,5 @@
 ---
-title: New Skills  --  June 18, 2026 (Final Sweep  --  OpenClaw Extensions)
+title: "New Skills"
 description: 8 newly discovered skills from aradotso/hermes-skills  --  QQ bot, MemX memory plugin, executive assistant suite, and agent building tutorial. Final sweep of the day.
 ---
 

--- a/hermes/skills/marketplace/new-june18-2026-update2/index.md
+++ b/hermes/skills/marketplace/new-june18-2026-update2/index.md
@@ -1,5 +1,5 @@
 ---
-title: New Skills  --  June 18, 2026 Update 2 (HyperFrames Video Ecosystem)
+title: "New Skills"
 description: 6 newly catalogued skills  --  the official Hermes Agent hyperframes skill (nousresearch) plus 5 HyperFrames SDK skills from heygen-com/hyperframes (103K+ installs each)  --  enabling agentic HTML-based video creation.
 ---
 

--- a/hermes/skills/marketplace/new-june18-2026/index.md
+++ b/hermes/skills/marketplace/new-june18-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: New Skills  --  June 18, 2026 (nousresearch/hermes-agent expansion)
+title: "New Skills"
 description: 32 new Hermes Agent skills discovered June 18, 2026 from nousresearch/hermes-agent  --  macOS desktop automation, Node.js/Python debugging, smart home control, subagent workflows, music generation, and more.
 ---
 

--- a/hermes/skills/marketplace/new-june19-2026-update/index.md
+++ b/hermes/skills/marketplace/new-june19-2026-update/index.md
@@ -1,5 +1,5 @@
 ---
-title: New Skills  --  June 19, 2026 Update (ECC-Hermes 36-pack, SkillSpector Vetting, AgentMint)
+title: "New Skills"
 description: 6 newly discovered Hermes skill repos  --  36-skill ECC pack, NVIDIA SkillSpector vetting pipeline, AgentMint subagent routing, devops/scraping skills, SEO/WordPress marketing pack, and Herman's execution playbook.
 ---
 

--- a/hermes/skills/marketplace/new-june19-2026/index.md
+++ b/hermes/skills/marketplace/new-june19-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: New Skills  --  June 19, 2026 (Hermes AgentMesh + Windows Native)
+title: "New Skills"
 description: 4 newly discovered skills and tools  --  async multi-agent message bus, Windows-native setup package, polymarket trading bot, and video translation. Plus Graphify adds Hermes platform support.
 ---
 

--- a/hermes/skills/marketplace/new-june22-2026-late/index.md
+++ b/hermes/skills/marketplace/new-june22-2026-late/index.md
@@ -1,5 +1,5 @@
 ---
-title: "New Hermes Skill Repo  --  aawobdev/hermes-skills (Blueprint Orchestration)"
+title: "New Hermes Skill Repo"
 description: "12 newly discovered Hermes Agent skills from aawobdev/hermes-skills  --  a complete multi-agent blueprint orchestration system: Architect, Developer, Tester, Designer, DevOps, Security Auditor, End-User, Researcher, Orchestrator, Model Routing, Prompting Standards"
 ---
 

--- a/hermes/skills/marketplace/new-june26-2026-afternoon/index.md
+++ b/hermes/skills/marketplace/new-june26-2026-afternoon/index.md
@@ -1,5 +1,5 @@
 ---
-title: New June 26, 2026 (Afternoon) — Agenthood 14-Agent Team + Letta AI 24-Skill Harness
+title: "June 26, 2026 (Afternoon) — Agenthood 14-Agent Team"
 description: 38 newly catalogued skills — Agenthood's full AI engineering team (14 specialized agent roles) and Letta Code's complete 24-skill agent harness. Multi-agent architecture, memory systems, and self-improving agent infrastructure.
 ---
 

--- a/hermes/skills/marketplace/new-june27-2026/index.md
+++ b/hermes/skills/marketplace/new-june27-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: "New June 27, 2026 — Skills Gallery (1,672+ Skills), A2A Bridge, Flight Recorder, and 7 More"
+title: "June 27, 2026 — Skills Gallery (1,672"
 description: "9 newly discovered Hermes Agent repos — Skills Gallery mega-collection (1,672+ skills across 49 categories), Agent-to-Agent Protocol bridge, autonomy flight recorder, WeChat plugin, Coolify ARM64 deploy, Walkie-Talkie, ztk context compressor, Robert Greene skill, and Gruvbox skin"
 ---
 

--- a/hermes/skills/marketplace/new-june28-2026/index.md
+++ b/hermes/skills/marketplace/new-june28-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: "New June 28, 2026 — Threads Growth Skill, NemoClaw User Guide, Huawei Hermes Deployment"
+title: "June 28, 2026 — Threads Growth Skill"
 description: "3 newly discovered skills — Threads growth automation (745 installs), NemoClaw security user guide (99 installs), Huawei Cloud Hermes deployment (43 installs)"
 ---
 

--- a/hermes/skills/marketplace/new-june29-2026-update/index.md
+++ b/hermes/skills/marketplace/new-june29-2026-update/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 June 29, 2026 (Update) — OpenClaw/Clawd Ecosystem: 25 New Skills from 9 Repos (43K+ Total Installs)"
+title: "June 29, 2026 (Update) — OpenClaw/Clawd Ecosystem"
 description: "June 29, 2026 update: 25 new skills discovered across 9 OpenClaw/Clawd ecosystem repos — clawdis (14 skills), clawdirect (2), clawdstrike (1), plus security, backup, and integrations."
 ---
 

--- a/hermes/skills/marketplace/new-june29-2026/index.md
+++ b/hermes/skills/marketplace/new-june29-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 June 29, 2026 — Coding Posture, Ultimate Humanizer, Clean Slate, Delegate Skills, AutoLoRA, WhatsApp Secretary, Safari Web Agent (7 repos, 7 skills)"
+title: "June 29, 2026 — Coding Posture"
 description: "New Hermes skills discovered June 29, 2026: task-aware coding modes, anti-AI-slop humanizer, session verification, background delegation, self-fine-tuning, WhatsApp integration, and native Safari automation."
 ---
 

--- a/hermes/skills/marketplace/new-june30-2026-update/index.md
+++ b/hermes/skills/marketplace/new-june30-2026-update/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 June 30, 2026 (Update) — Matt Pocock Engineering Skills + OpenClaw Loader"
+title: "June 30, 2026 (Update) — Matt Pocock Engineering Skills"
 description: "7 additional Hermes skills discovered June 30, 2026 late sweep: 5 Matt Pocock engineering skills (1.3M+ combined installs), ChromaDB integration, OpenClaw skill loader."
 ---
 

--- a/hermes/skills/marketplace/new-june30-2026-update2/index.md
+++ b/hermes/skills/marketplace/new-june30-2026-update2/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 June 30, 2026 (Update 2) — xurl X/Twitter, TimesFM Forecasting, ClawSec Security Suite"
+title: "June 30, 2026 (Update 2) — xurl X/Twitter"
 description: "12 additional Hermes-relevant skills discovered June 30, 2026 evening sweep: xurl (X/Twitter from Nous Research), TimesFM forecasting (Google), and 10 ClawSec security skills for the OpenClaw ecosystem."
 ---
 

--- a/hermes/skills/marketplace/new-june30-2026/index.md
+++ b/hermes/skills/marketplace/new-june30-2026/index.md
@@ -1,5 +1,5 @@
 ---
-title: "🆕 June 30, 2026 — OpenClaw Ecosystem Expansion, HermesPet, MCP Dev Toolkit (14 repos, 24 skills)"
+title: "June 30, 2026 — OpenClaw Ecosystem Expansion"
 description: "New Hermes skills discovered June 30, 2026: 1 Hermes variant, 13 OpenClaw ecosystem skills, 1 Clawdbot skill, 9 MCP development skills. Crosses 7 categories."
 ---
 

--- a/hermes/skills/skill-marketplaces.md
+++ b/hermes/skills/skill-marketplaces.md
@@ -1,5 +1,5 @@
 ---
-title: Hermes Agent Skill Marketplaces  --  Discovery, Publishing & Quality Standards
+title: "Hermes Agent Skill Marketplaces"
 description: Navigate Hermes Agent skill marketplaces for discovering and publishing skills. Quality tiers, marketplace comparison, publishing guides, community standards, and how to find the best community-built AI agent skills.
 category: skills
 tags: [hermes-agent, skills, marketplace, publishing, quality-tiers, community, discovery, curation]


### PR DESCRIPTION
Shortens 239 doc page titles to under 60 chars per the SEO title-length rule (240 files, frontmatter-only edits).

Note: the original branch `claude/docs-shorten-long-titles` is blocked by a GitHub ghost-PR record (a half-created PR — the phantom '#70' Ben saw — that renders nowhere but blocks new PRs on that head). Re-pointed to a fresh branch to get a clean PR. Same commit (47cac6ce). Powered by CorpusIQ