### PR TITLE
fix(docs): repair Hermes frontmatter baseline

### DIFF
--- a/hermes/index.md
+++ b/hermes/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Hermes Community Hub — 440+ Tools & Resources"
-description: "The largest structured Hermes Agent knowledge base
-last_updated: "2026-08-13" — 440+ tools, skills, MCP servers, agents, blueprints, and case studies. Built by the community. Updated daily."
+description: "The largest structured Hermes Agent knowledge base — 440+ tools, skills, MCP servers, agents, blueprints, and case studies. Built by the community. Updated daily."
+last_updated: "2026-08-13"
 canonical: "https://www.corpusiq.io/docs/hermes/"
 robots: "index,follow"
 tags: ["hermes agent", "ai agent", "nous research"]

--- a/hermes/skills/catalog/caveman-skills-setup.md
+++ b/hermes/skills/catalog/caveman-skills-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Caveman Skills — Agent Coding Workflow Suite Setup Guide for Hermes Agents
-description: Install juliusbrussee/caveman (2.2M combined installs) — 23 skills for caveman-style agent coding: commits, reviews, context compression, stats, multi-agent crews, and evidence-driven fixes.
+description: "Install juliusbrussee/caveman (2.2M combined installs) — 23 skills for caveman-style agent coding: commits, reviews, context compression, stats, multi-agent crews, and evidence-driven fixes."
 canonical: "https://www.corpusiq.io/docs/hermes/skills/catalog/caveman-skills-setup/"
 robots: "index,follow"
 last_updated: "2026-08-12"

--- a/hermes/skills/catalog/skills-101-superpowers-setup.md
+++ b/hermes/skills/catalog/skills-101-superpowers-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Skills-101 Superpowers — AI Media & Automation Pack Setup Guide for Hermes Agents
-description: Install skills-101/superpowers (488.4K combined installs) — 86 skills: AI video/image/avatar generation, ElevenLabs audio cluster, twitter automation, agent browser, Remotion rendering, and growth playbooks.
+description: "Install skills-101/superpowers (488.4K combined installs) — 86 skills: AI video/image/avatar generation, ElevenLabs audio cluster, twitter automation, agent browser, Remotion rendering, and growth playbooks."
 canonical: "https://www.corpusiq.io/docs/hermes/skills/catalog/skills-101-superpowers-setup/"
 robots: "index,follow"
 last_updated: "2026-08-12"

--- a/hermes/skills/catalog/stablyai-orca-setup.md
+++ b/hermes/skills/catalog/stablyai-orca-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Stably Orca — Agent Orchestration CLI Setup Guide for Hermes Agents
-description: Install stablyai/orca (317.5K combined installs) — 15 skills for the Orca agent orchestration CLI: orca-cli (125K), orchestration (104.2K), computer-use (77.3K), Linear integration, emulators, and auto PR workflows.
+description: "Install stablyai/orca (317.5K combined installs) — 15 skills for the Orca agent orchestration CLI: orca-cli (125K), orchestration (104.2K), computer-use (77.3K), Linear integration, emulators, and auto PR workflows."
 canonical: "https://www.corpusiq.io/docs/hermes/skills/catalog/stablyai-orca-setup/"
 robots: "index,follow"
 last_updated: "2026-08-12"

--- a/hermes/skills/catalog/warpdotdev-common-skills-setup.md
+++ b/hermes/skills/catalog/warpdotdev-common-skills-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Warp Common Skills — Spec-Driven Development Workflow Setup Guide for Hermes Agents
-description: Install warpdotdev/common-skills (411.2K combined installs) — 25 skills from the Warp terminal team: spec-driven implementation, PR review, CI diagnosis, merge conflict resolution, and spec validation.
+description: "Install warpdotdev/common-skills (411.2K combined installs) — 25 skills from the Warp terminal team: spec-driven implementation, PR review, CI diagnosis, merge conflict resolution, and spec validation."
 canonical: "https://www.corpusiq.io/docs/hermes/skills/catalog/warpdotdev-common-skills-setup/"
 robots: "index,follow"
 last_updated: "2026-08-12"

--- a/hermes/skills/marketplace/new-aug12-2026-evening/index.md
+++ b/hermes/skills/marketplace/new-aug12-2026-evening/index.md
@@ -1,6 +1,6 @@
 ---
 title: New Skills — August 12, 2026 (Evening)
-description: Evening skills.sh sweep — 7 new publisher clusters, 198 skills, 31M+ installs: Lark/Feishu office suite (25M), RigorPilot research (2.6M), Caveman workflow (2.2M), Skills-101 Superpowers (488K), Warp Common Skills (411K), Uizze UI quality (395K), Stably Orca (318K).
+description: "Evening skills.sh sweep — 7 new publisher clusters, 198 skills, 31M+ installs: Lark/Feishu office suite (25M), RigorPilot research (2.6M), Caveman workflow (2.2M), Skills-101 Superpowers (488K), Warp Common Skills (411K), Uizze UI quality (395K), Stably Orca (318K)."
 canonical: "https://www.corpusiq.io/docs/hermes/skills/marketplace/new-aug12-2026-evening/"
 robots: "index,follow"
 last_updated: "2026-08-12"


### PR DESCRIPTION
Closes #94

## Problem

The required frontmatter validator fails on current `main`, blocking unrelated documentation PRs.

## Change

- restore the accidentally split Hermes Hub description and `last_updated` field;
- quote five descriptions containing YAML-significant `: ` sequences;
- edit the tracked `hermes/` sources, whose `docs/hermes/` mirror resolves to identical content.

## Verification

- RED on clean `origin/main`: 12 reported failures across six tracked files and their six mirrored paths;
- GREEN after the fix: `frontmatter check: scanned 2737 Markdown files` and `all frontmatter is valid`;
- all six tracked files match their `docs/hermes/` mirrors byte-for-byte;
- `git diff --check` passed.

After merge, rerun the blocked check on CorpusIQ/corpusiq-docs#93.