### PR TITLE
fix(docs): publish truthful directory disclosures

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@
 
 ## How it works — 3 steps
 
-1. **Connect** — Plug in your existing tools (30-second OAuth, read-only, no data leaves your control)
+1. **Connect** — Authorize external-source retrieval through each provider's documented OAuth flow
 2. **Ask** — Type a question in ChatGPT, Claude, or any MCP-compatible assistant
-3. **Get answers** — Live data flows directly into the AI's response. No middleman.
+3. **Get answers** — Source data passes through CorpusIQ to the requesting AI client with citations; that client's conversation policy applies after receipt.
 
 **Read the full docs:** [corpusiq.io/docs](https://www.corpusiq.io/docs/) — Quickstart, API reference, connector guides, troubleshooting.
 

--- a/chatgpt-integration.md
+++ b/chatgpt-integration.md
@@ -44,6 +44,6 @@ All 37+ connectors are available through ChatGPT:
 
 ## Security
 
-CorpusIQ is read-only. ChatGPT can query your data but cannot modify anything. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may be retained for up to 30 days.
+CorpusIQ external-source connector tools use read-only retrieval and do not write back to vendor systems. Explicit CorpusIQ control-plane tools can update or remove user-declared CorpusIQ state and carry separate safety annotations. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may be retained for up to 30 days.
 
 See our [ChatGPT connector guide](connectors/chatgpt-business-data-connector.md) for detailed setup.

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -4,7 +4,7 @@ CorpusIQ connects to your business tools through read-only MCP connectors.
 Each connector requires a one-time OAuth authentication — you click Connect,
 approve the permission screen, and your AI tools can query live data immediately.
 
-CorpusIQ never writes back to your accounts. Every connector is read-only.
+The external-source connectors in this directory are designed for read-only retrieval and do not write back to connected vendor accounts. Separately annotated CorpusIQ control-plane tools are outside this connector directory.
 
 ## Index
 

--- a/connectors/ga4.md
+++ b/connectors/ga4.md
@@ -39,7 +39,7 @@ Show me real-time active users right now broken down by device.
 2. Click **Google Analytics 4**
 3. Sign in with the Google account that has access to your GA4 property
 4. Select the GA4 property you want to connect
-5. Done — CorpusIQ is read-only and never modifies your Analytics data
+5. Done — the GA4 connection is read-only and never modifies your Analytics data
 
 ## What data CorpusIQ can see
 

--- a/content/blog/connected-business-to-ai.md
+++ b/content/blog/connected-business-to-ai.md
@@ -69,9 +69,9 @@ That shift — from asking what's easy to asking what matters — is the real va
 
 ## The Setup Nobody Tells You About
 
-Every connector is read-only. The AI can see your data but can't change it. No accidental charges, no deleted orders, no modified invoices. This matters more than you'd think — once you know the AI can only read, you stop worrying about what it might do.
+External-source connector tools are designed for read-only retrieval. They can return vendor data to the requesting AI client but do not write charges, orders, or invoices back to those systems. Separately annotated CorpusIQ control-plane tools can update or remove user-declared CorpusIQ state.
 
-Also: your data never goes through some third-party server for "processing." The connectors run as MCP tools and the data flows directly into the AI's context window. It's like copy-pasting, but automatic.
+Connector results pass through CorpusIQ to the requesting AI client. Direct MCP retrieval does not build a separate customer-file index; the selected AI client's conversation and retention policies still apply.
 
 ## What I'd Do Differently
 

--- a/content/blog/death-of-dashboards.md
+++ b/content/blog/death-of-dashboards.md
@@ -69,9 +69,9 @@ A dashboard tells you revenue is up 12%. That's a "what." The AI, connected to y
 
 ## The Read-Only Safety Net
 
-Every connector is read-only. The AI can query your QuickBooks P&L but it can't cut a check. It can search HubSpot deals but it can't close one. It can pull Stripe charges but it can't issue a refund.
+External-source connector tools are read-only. The AI can query a QuickBooks P&L without cutting a check, search HubSpot deals without closing one, and retrieve Stripe charges without issuing a refund. Separately annotated CorpusIQ control-plane tools operate only on user-declared CorpusIQ state.
 
-This matters for two reasons. First, security teams stop objecting once they understand it's read-only. Second, you stop worrying about what the AI might do. It can only read. It can only answer.
+This gives security teams a concrete boundary: vendor-system retrieval does not write back, while the small set of CorpusIQ control-plane mutations is explicit and separately annotated.
 
 ## The Tool Stack That Actually Works
 

--- a/content/seo/seo-best-mcp-platform.md
+++ b/content/seo/seo-best-mcp-platform.md
@@ -10,7 +10,7 @@ Here's what actually matters — and what's just marketing.
 
 If a platform can write to your QuickBooks or Stripe, walk away. The AI should query your data, not modify it. Look for platforms that are read-only by design, not read-only by request.
 
-CorpusIQ: Every connector is read-only. The AI can't create transactions, modify entries, or change anything. CASA Tier 2 certified.
+CorpusIQ: External-source connector tools use read-only retrieval and do not write transactions or entries back to vendor systems. Explicit CorpusIQ control-plane operations are separately annotated. CASA Tier 2 certified.
 
 ### 2. How many connectors you actually need
 

--- a/content/seo/seo-mcp-connector-directory.md
+++ b/content/seo/seo-mcp-connector-directory.md
@@ -74,7 +74,7 @@ This is the definitive directory of business data connectors available through M
 
 ## What Makes These Connectors Different
 
-**Read-only by design:** Every connector is read-only. The AI can query data but cannot create, modify, or delete anything.
+**Read-only external retrieval:** Connector tools can query vendor data but do not create, modify, or delete records in those connected systems. Separately annotated CorpusIQ control-plane tools operate on user-declared CorpusIQ state.
 
 **OAuth-native:** No API keys to manage. Each connector uses OAuth — 30 seconds to connect, instant to revoke.
 

--- a/content/seo/seo-mcp-for-enterprise.md
+++ b/content/seo/seo-mcp-for-enterprise.md
@@ -19,9 +19,9 @@ Meanwhile, the CEO wants to know "how are we doing this quarter?" and nobody can
 
 ## How MCP solves enterprise access without breaking security
 
-**Read-only by design:** Every connector is read-only. Finance knows Sales can query P&L data without modifying a single entry. IT knows the AI can pull support tickets without closing any.
+**Read-only external retrieval:** Finance can query P&L data without modifying vendor entries, and IT can retrieve support tickets without closing them. Explicit CorpusIQ control-plane operations are separate and annotated.
 
-**OAuth-native, per-user:** Each user authenticates via their own OAuth. No shared API keys. Revoke access instantly. Audit trail shows who queried what.
+**OAuth-native, per-user:** Each user authenticates via their own OAuth. No shared API keys. Disconnects commit a durable inactive state; credential-cleanup failures are surfaced instead of hidden. Operational logs record scoped query activity.
 
 **No ETL warehouse:** Source systems remain authoritative. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may persist for up to 30 days.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ tags: ["hermes agent", "ai agent", "documentation"]
 
 CorpusIQ is a private AI acceleration layer that connects 40+ business tools to ChatGPT, Claude, and Perplexity via the Model Context Protocol (MCP). One question. Cited answers from all your tools.
 
-CorpusIQ acts as a read-only bridge between your SaaS applications and AI assistants. Direct MCP requests retrieve source records live without retaining raw customer files or full connector response payloads. Operational query text, tool-call metadata, and bounded outcome summaries are retained for up to 30 days. Every response includes citations back to the source tool, so you can verify accuracy in one click.
+CorpusIQ provides read-only external-source retrieval between authorized SaaS applications and AI assistants. Explicit CorpusIQ control-plane tools that update or remove user-declared state are separately annotated. Direct MCP requests retrieve source records live without retaining raw customer files or full connector response payloads. Operational query text, tool-call metadata, and bounded outcome summaries are retained for up to 30 days. Every response includes citations back to the source tool, so you can verify accuracy in one click.
 
 ## Key Capabilities
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -66,7 +66,7 @@ Your backend forwards authenticated user requests to CorpusIQ. The API token nev
 
 ### Token Revocation
 
-Tokens can be revoked at any time from the Dashboard (**Settings → API → Revoke All Tokens**). Revocation takes effect immediately across all active sessions. If a token is compromised, revoke it and generate a new one.
+Tokens can be revoked from the Dashboard (**Settings → API → Revoke All Tokens**). The service commits an inactive state before credential cleanup and surfaces cleanup failures for retry. If a token is compromised, revoke it through CorpusIQ and the provider, then generate a new one.
 
 ## Header Reference
 
@@ -102,7 +102,7 @@ A: API tokens expire after 60 minutes with server-side refresh detection. Use re
 A: AI agents use OAuth 2.0 Device Authorization Grant (RFC 8628). The agent receives a device code, you verify once via browser, and the agent gets a persistent refresh token  --  no browser needed for ongoing access.
 
 **Q: How do I revoke a CorpusIQ API token?**  
-A: Revoke tokens immediately from the CorpusIQ Dashboard. Revocation takes effect across active sessions. To request deletion of account data, contact privacy@corpusiq.io; CorpusIQ responds to privacy requests within 30 days.
+A: Disconnect the connector from the CorpusIQ Dashboard. The service commits an inactive state before credential cleanup and surfaces cleanup failures for retry; provider-side revocation is also available through the source platform. To request deletion of account data, contact privacy@corpusiq.io; CorpusIQ responds to privacy requests within 30 days.
 
 ## Internal Links
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -76,7 +76,7 @@ The [demo.corpusiq.io](https://demo.corpusiq.io) chat interface is a web applica
 ## Frequently Asked Questions
 
 **Q: What is the CorpusIQ system architecture?**  
-A: CorpusIQ uses a three-layer architecture: AI clients (Claude, ChatGPT, Cursor) connect via MCP protocol to the CorpusIQ MCP endpoint, which routes queries through the connector layer to 36+ business data sources. All access is read-only via OAuth 2.0.
+A: CorpusIQ uses a three-layer architecture: AI clients (Claude, ChatGPT, Cursor) connect via MCP protocol to the CorpusIQ MCP endpoint, which routes queries through the connector layer to business data sources. External-source retrieval uses documented OAuth scopes and does not write back to vendor systems; explicit CorpusIQ control-plane writes are separately annotated.
 
 **Q: How does data flow through CorpusIQ?**  
 A: AI agent sends query via MCP → MCP endpoint authenticates request → Tool registry maps query to connectors → Connector retrieves data from source API → Data is normalized and returned → Agent presents answer to user. All steps are logged for audit.

--- a/docs/claude-for-shopify.md
+++ b/docs/claude-for-shopify.md
@@ -92,7 +92,7 @@ Yes. Claude's outputs include methodology descriptions, data source citations, a
 CorpusIQ uses a read-only Shopify connection and encrypted transport. Data handling inside Claude follows the terms and settings of the Anthropic plan you choose; review Anthropic's current policy before sending sensitive store data.
 
 ### Can Claude make changes to my Shopify store?
-No. The Shopify connection through CorpusIQ is read-only. Claude can analyze data and make strategic recommendations, but it cannot execute changes in your Shopify admin  --  no product modifications, order changes, or setting adjustments. Human implementation is always required.
+No. The Shopify connector uses read-only vendor retrieval. Claude can analyze data and make strategic recommendations, but it cannot execute changes in your Shopify admin  --  no product modifications, order changes, or setting adjustments. Human implementation is always required.
 
 ### What types of analysis is Claude best for?
 Claude excels at: multi-year trend analysis, full customer base analysis, product portfolio optimization, complex cohort modeling, inventory optimization at scale, attribution modeling, competitive analysis, strategic planning, and any analysis requiring sustained reasoning across large datasets.

--- a/docs/connect-netsuite-to-chatgpt.md
+++ b/docs/connect-netsuite-to-chatgpt.md
@@ -21,7 +21,7 @@ This page covers the architecture, what you can ask, enterprise security, and ho
 <details>
 <summary><strong>What NetSuite data can ChatGPT access?</strong></summary>
 
-CorpusIQ's NetSuite integration provides access to core ERP objects: sales orders, customers, invoices, inventory, items, financial reports, and project data. ChatGPT can retrieve individual records, list records with filters, and aggregate data across objects. All access is read-only  --  no record creation, editing, or deletion.
+CorpusIQ's NetSuite integration provides access to core ERP objects: sales orders, customers, invoices, inventory, items, financial reports, and project data. ChatGPT can retrieve individual records, list records with filters, and aggregate data across objects. NetSuite connector retrieval is read-only  --  no record creation, editing, or deletion in that source.
 </details>
 
 <details>

--- a/docs/connect-salesforce-to-chatgpt.md
+++ b/docs/connect-salesforce-to-chatgpt.md
@@ -21,7 +21,7 @@ This page covers the architecture, what you can ask, enterprise security conside
 <details>
 <summary><strong>What Salesforce data can ChatGPT access?</strong></summary>
 
-CorpusIQ provides MCP tools that map to core Salesforce objects: Accounts, Contacts, Leads, Opportunities, Cases, and custom objects. ChatGPT can search across these objects, retrieve individual records, list records with filters, and combine data across multiple objects. All access is read-only  --  no create, update, or delete operations exist.
+CorpusIQ provides MCP tools that map to core Salesforce objects: Accounts, Contacts, Leads, Opportunities, Cases, and custom objects. ChatGPT can search across these objects, retrieve individual records, list records with filters, and combine data across multiple objects. Salesforce connector retrieval is read-only  --  no create, update, or delete operations exist for that source.
 </details>
 
 <details>

--- a/docs/corpusiq-vs-zapier.md
+++ b/docs/corpusiq-vs-zapier.md
@@ -81,7 +81,7 @@ Every answer reflects the current state of your systems. There's no batch window
 Zapier connects to 7,000+ apps, far more than CorpusIQ's 40+ connectors. For niche tools, Zapier is likely to have an integration.
 
 ### 2. Write Capabilities
-Zapier can create, update, and delete data across apps. CorpusIQ is read-only by design. If you need to automate record creation  --  e.g., "When a Typeform submission comes in, create a HubSpot contact"  --  Zapier is the tool.
+Zapier can create, update, and delete data across apps. CorpusIQ external-source connector tools use read-only retrieval and do not write records back to those apps; its separately annotated control-plane tools operate on user-declared CorpusIQ state. If you need to automate vendor-record creation  --  e.g., "When a Typeform submission comes in, create a HubSpot contact"  --  Zapier is the tool.
 
 ### 3. Multi-Step Logic
 Zapier supports branching paths, filters, delays, and conditional logic within workflows. Complex automations with decision trees are Zapier's strength.

--- a/docs/enterprise-ai-data-access.md
+++ b/docs/enterprise-ai-data-access.md
@@ -48,19 +48,19 @@ CorpusIQ's enterprise AI data access architecture is built on five pillars:
 
 **Per-user OAuth scoping.** When a user connects a data source through OAuth, the scopes granted are the minimum necessary for read-only business intelligence. Each user authenticates individually  --  there are no shared service accounts that would obscure who accessed what data.
 
-### 2. Read-Only by Default Architecture
+### 2. Read-Only External Retrieval with Explicit Control-Plane Writes
 
-The most important security property of CorpusIQ's enterprise AI data access layer is that it is read-only by default. This is enforced at multiple levels:
+CorpusIQ separates external-source retrieval from writes to user-declared CorpusIQ control-plane state. The boundary is enforced at multiple levels:
 
-- **Protocol level.** MCP tool definitions are registered as read-only. The AI model cannot call a "create" or "update" operation because those tools are not exposed.
+- **Protocol level.** External-source retrieval tools carry read-only annotations. Explicit control-plane tools that update or remove user-declared facts, decisions, metric specifications, and source manifests carry separate non-read-only and destructive annotations where applicable.
 
-- **OAuth scope level.** Connectors request read-only scopes. For QuickBooks, `com.intuit.quickbooks.accounting.read`. For Shopify, `read_orders`, `read_products`, `read_customers`. For HubSpot, read-only access to contacts, deals, and companies.
+- **OAuth scope level.** External-source connectors request the documented retrieval scopes. For QuickBooks, `com.intuit.quickbooks.accounting.read`. For Shopify, `read_orders`, `read_products`, `read_customers`. For HubSpot, read-only access to contacts, deals, and companies.
 
-- **Connector level.** Even if broader OAuth scopes were granted, CorpusIQ's connector implementations validate operations against a capability matrix and block write operations.
+- **Connector level.** External-source connector implementations validate operations against a capability matrix and block write-back operations to connected vendor systems.
 
-- **AI model level.** The tool descriptions the AI model sees describe read-only capabilities  --  "List Salesforce Opportunities" not "Create Salesforce Opportunity."
+- **AI model level.** External connector descriptions identify retrieval behavior, while CorpusIQ control-plane descriptions state the supported state mutation explicitly.
 
-This defense-in-depth approach means that accidental data modification is architecturally impossible. The system cannot write data unless an administrator explicitly enables write operations at all four levels  --  a deliberate, multi-step process that creates an audit trail at each step.
+This defense-in-depth approach prevents external connector tools from writing back to connected vendor systems. Supported CorpusIQ control-plane mutations remain explicit, user-invoked, separately annotated, and auditable.
 
 ### 3. Comprehensive Audit Trails
 
@@ -172,7 +172,7 @@ A: CorpusIQ maintains a SOC 2 aligned security posture and is CASA Tier 2 certif
 A: Through role-based access control (RBAC) mapped to your existing directory groups. Each role has specific data source permissions. OAuth connections are per-user, so each user authenticates individually and inherits their own permissions from the source platform.
 
 **Q: Can CorpusIQ write data to our business systems?**
-A: Connected third-party business systems are read-only by design. CorpusIQ control-plane tools may update user-declared CorpusIQ state or revoke credentials, but they do not write back to connected source systems.
+A: Connected third-party business systems are read-only by design. Explicit CorpusIQ control-plane tools may update or remove user-declared facts, decisions, metric specifications, and source manifests, but they do not write back to connected source systems.
 
 **Q: Where is CorpusIQ infrastructure located, and can we control data residency?**
 A: Enterprise customers can request a deployment region, subject to validation of storage, network transit, source-provider processing, the selected AI client, logs, and backups. Contact sales@corpusiq.io for a customer-specific residency assessment.
@@ -181,7 +181,7 @@ A: Enterprise customers can request a deployment region, subject to validation o
 A: The Azure Log Analytics workspace retains operational MCP logs for 30 days.
 
 **Q: How is this different from giving employees direct API access to our systems?**
-A: Direct API access requires granting credentials that can potentially read, write, or modify data  --  and those credentials can be leaked, misused, or forgotten. CorpusIQ provides a read-only abstraction layer with per-user authentication, granular RBAC, full audit trails, and no persistent credentials for end users to manage.
+A: Direct API access requires granting credentials that can potentially read, write, or modify data  --  and those credentials can be leaked, misused, or forgotten. CorpusIQ provides read-only external-source retrieval with separately annotated CorpusIQ control-plane operations, per-user authentication, granular RBAC, and audit trails.
 
 **Q: What's the deployment timeline for an enterprise rollout?**
 A: A departmental pilot can be operational in days  --  SSO configuration takes 1–2 hours, and data source connections take minutes each. Full enterprise deployment with governance policies, role mappings, and multi-department rollout typically takes 2–4 weeks.

--- a/docs/how-to-build-an-executive-ai-dashboard.md
+++ b/docs/how-to-build-an-executive-ai-dashboard.md
@@ -174,7 +174,7 @@ A: Traditional dashboards show predefined views. This answers ANY question in re
 A: Yes. Each executive can have their own CorpusIQ account or share a team account.
 
 **Q: How secure is executive data?**  
-A: CorpusIQ is read-only and inherits source permissions. Financial data in QuickBooks is only visible to users authorized in QuickBooks.
+A: CorpusIQ external-source retrieval is read-only and inherits source permissions. Financial data in QuickBooks is only visible to users authorized in QuickBooks. Separately annotated CorpusIQ control-plane tools operate on user-declared CorpusIQ state.
 
 **Q: Can I get alerts when metrics cross thresholds?**  
 A: Not natively  --  CorpusIQ is query-on-demand. You can set up reminders to check key metrics at regular intervals.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ A: CorpusIQ uses MCP (Model Context Protocol)  --  an open standard that lets AI
 A: CorpusIQ supports 40+ business tools including HubSpot, Salesforce, QuickBooks, Stripe, Shopify, GA4, Google Ads, Meta Ads, Slack, Gmail, Google Drive, Notion, PostgreSQL, MSSQL, MongoDB, and more  --  see the full connectors directory.
 
 **Q: Is my data secure with CorpusIQ?**  
-A: Yes. CorpusIQ is read-only by default, does not retain raw customer files or full connector response payloads, uses TLS 1.3 encryption, and is SOC 2 aligned. Operational query and audit logs are retained for up to 30 days. All data source connections use OAuth with minimum required scopes.
+A: Yes. External-source connector tools use read-only retrieval, while explicit CorpusIQ control-plane tools are separately annotated. Direct MCP does not retain raw customer files or full connector response payloads, uses TLS encryption, and follows a SOC 2 aligned posture. Operational query and audit logs are retained for up to 30 days. Data-source connections use documented OAuth scopes.
 
 **Q: How quickly can I start using CorpusIQ?**  
 A: Sign up at corpusiq.io, connect your first data source via OAuth (60 seconds), and start asking natural-language questions. Full setup takes under 5 minutes. See the Quick Start guide for step-by-step instructions.

--- a/docs/mcp-for-small-business.md
+++ b/docs/mcp-for-small-business.md
@@ -89,7 +89,7 @@ With these five categories connected, a small business owner can answer virtuall
 
 **Self-service onboarding.** No implementation calls, no consulting engagements. The setup is designed to be completed by a business owner, not an IT team.
 
-**Read-only safety.** Small business owners can connect their financial systems without worrying about the AI accidentally modifying data. Read-only defaults mean zero risk of unintended changes.
+**Read-only external retrieval.** Small business owners can query connected financial systems without the connector tools writing back to those vendor records. Explicit CorpusIQ control-plane changes are separately annotated.
 
 **Mobile-friendly queries.** Ask questions from your phone through any MCP-compatible AI client. Check business health during your morning coffee without opening a laptop.
 
@@ -110,7 +110,7 @@ CorpusIQ offers plans starting at accessible SMB price points. Visit the CorpusI
 <details>
 <summary><strong>Is my data secure? Can the AI accidentally delete something?</strong></summary>
 
-CorpusIQ defaults to read-only access for all connectors. The AI cannot modify, delete, or create data. It can only read and report. For small businesses, this means zero risk of the AI making unintended changes to your QuickBooks or Shopify data.
+CorpusIQ external-source connector tools use read-only retrieval and do not modify, delete, or create records in connected vendor systems such as QuickBooks or Shopify. Explicit CorpusIQ control-plane tools operate only on user-declared CorpusIQ state and carry separate safety annotations.
 </details>
 
 <details>

--- a/docs/mcp-security-best-practices.md
+++ b/docs/mcp-security-best-practices.md
@@ -46,7 +46,7 @@ OAuth tokens are the keys to your data. Managing them securely is critical:
 
 **Automatic token rotation.** When a refresh token is used to obtain a new access token, some providers also rotate the refresh token. CorpusIQ handles this rotation transparently, ensuring the latest refresh token is always stored.
 
-**Token revocation.** Users can revoke access to any connected platform at any time through the CorpusIQ dashboard. Revocation immediately deletes all stored tokens for that platform and terminates any in-flight requests.
+**Token revocation.** Users can disconnect a connected platform through the CorpusIQ dashboard. The service commits an inactive state before credential cleanup; cleanup failures are surfaced for retry rather than reported as successful deletion. Provider-side revocation remains available through the connected platform.
 
 **Cross-user isolation.** Each user's tokens are cryptographically isolated. User A's Shopify token cannot be used to access User B's data, even if both users are in the same CorpusIQ organization. This isolation extends to the database layer  --  tokens are stored with user-scoped encryption keys.
 

--- a/docs/secure-ai-data-connectivity.md
+++ b/docs/secure-ai-data-connectivity.md
@@ -28,7 +28,7 @@ CorpusIQ uses HTTPS/TLS for data in transit and Azure-managed encryption for per
 CorpusIQ sits between your tools and the AI assistant. It sends the requesting AI client the source data needed for the requested tool result and citations; it does not give the model persistent provider access. Direct MCP requests do not build embeddings or file indexes.
 
 ### Can CorpusIQ modify my data?
-External source connectors are designed for read-only retrieval and do not write back to those connected vendor systems. CorpusIQ control-plane tools can update user-declared CorpusIQ state or revoke credentials when the user explicitly requests those actions. Review the exact vendor scopes on each OAuth authorization screen and the safety annotations on the selected tool.
+External source connectors are designed for read-only retrieval and do not write back to those connected vendor systems. Explicit CorpusIQ control-plane tools can update or remove user-declared facts, decisions, metric specifications, and source manifests when the user requests those actions. Review the exact vendor scopes on each OAuth authorization screen and the safety annotations on the selected tool.
 
 ### What encryption standards does CorpusIQ use?
 CorpusIQ uses HTTPS/TLS for data in transit and the encryption-at-rest controls of its managed Azure services. Customer-specific requirements for keys, rotation, residency, backups, or dedicated infrastructure should be validated during an enterprise security review rather than inferred from this overview.
@@ -64,7 +64,7 @@ AI Assistant → CorpusIQ MCP Server → HTTPS/TLS → Scoped OAuth → Business
 ## Benefits
 
 ### Read-Only External Retrieval
-External source connectors are designed not to write back to connected vendor systems. CorpusIQ control-plane operations, including credential revocation and user-declared state changes, remain explicit and separately annotated.
+External source connectors are designed not to write back to connected vendor systems. CorpusIQ control-plane operations that update or remove user-declared facts, decisions, metric specifications, and source manifests remain explicit and separately annotated.
 
 ### Scoped Data Handling
 Direct MCP requests use live retrieval without retaining raw customer files or full connector response payloads. Operational query logs are retained for up to 30 days. Optional indexed-search features have a separate embeddings-and-metadata lifecycle.

--- a/docs/security.md
+++ b/docs/security.md
@@ -19,7 +19,7 @@ CorpusIQ is designed with data privacy as a foundational principle. This page do
 | **SOC 2** | Aligned  --  formal certification is not claimed; controls are reviewed quarterly |
 | **GDPR** | Aligned  --  data minimization, user consent, deletion rights |
 | **Encryption** | AES-256 at rest, TLS 1.3 in transit |
-| **Access Model** | Read-only OAuth  --  no write permissions ever |
+| **Access Model** | Read-only external-source retrieval; explicit CorpusIQ control-plane writes are separately annotated |
 
 Contact: security@corpusiq.io · privacy@corpusiq.io
 
@@ -60,10 +60,10 @@ AES-256, managed keys, key rotation every 90 days.
 Private subnets, deny-by-default, WAF and rate limits on all public endpoints.
 
 ### Access
-Read-only OAuth scopes only. No write permissions on any connector. The specific scopes requested are visible on the OAuth authorization screen during connection setup.
+External-source connectors use the documented retrieval scopes and do not write back to vendor systems. Explicit CorpusIQ control-plane tools that mutate user-declared CorpusIQ state are separately annotated. Vendor scopes remain visible on the OAuth authorization screen during connection setup.
 
 ### Authentication
-API tokens have 60-minute expiry with server-side refresh detection. Tokens are never embedded in client-side code  --  server-side usage only. Token revocation takes effect immediately across all active sessions.
+API tokens have 60-minute expiry with server-side refresh detection. Tokens are never embedded in client-side code  --  server-side usage only. Disconnect commits an inactive state before credential cleanup; cleanup failures are surfaced for retry.
 
 ### Webhook Security
 CorpusIQ does not currently publish a customer-facing webhook event contract. Event schemas, authentication, and delivery guarantees will be documented only after their production routes are verified.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -21,7 +21,7 @@ robots: "index,follow"
 ---
 # Security
 
-CorpusIQ is designed with security as a foundational requirement. All access is read-only. We never write to your systems.
+CorpusIQ is designed with security as a foundational requirement. External-source connector access is read-only and does not write back to vendor systems. Explicit CorpusIQ control-plane tools can update or remove user-declared CorpusIQ state and carry separate safety annotations.
 
 ## Authentication
 
@@ -45,12 +45,8 @@ CorpusIQ is designed with security as a foundational requirement. All access is 
 
 ## Data Access
 
-### Read-Only Policy
-CorpusIQ is strictly read-only. We:
-- Query data from your connected sources
-- Normalize and present results
-- Never write, modify, or delete data
-- Never initiate transactions or changes
+### Scoped Access Policy
+External-source connector tools use read-only retrieval: they query connected sources, normalize results, and do not write back to those vendor systems or initiate vendor transactions. Explicit CorpusIQ control-plane tools can update or remove user-declared facts, decisions, metric specifications, and source manifests and carry separate safety annotations.
 
 ### Data Handling
 - Direct MCP retrieves source records on demand and delivers scoped results to the requesting client
@@ -88,8 +84,8 @@ Report security concerns to security@corpusiq.io. We respond within 24 hours.
 **Q: How does CorpusIQ authenticate users?**  
 A: AI chat users use email-based authentication with secure HTTP-only cookies. AI agent users use OAuth 2.0 Device Authorization Grant (RFC 8628) with refresh token rotation. Data source connections use OAuth 2.0 with scoped, read-only permissions.
 
-**Q: Is CorpusIQ data access read-only?**  
-A: Yes. CorpusIQ is strictly read-only. It queries data from connected sources, normalizes and presents results, but never writes, modifies, or deletes data, and never initiates transactions or changes.
+**Q: Is CorpusIQ data access read-only?**
+A: External-source retrieval is read-only and does not write back to connected vendor systems. Explicit CorpusIQ control-plane tools can modify user-declared CorpusIQ state and are separately annotated.
 
 **Q: What encryption does CorpusIQ use?**  
 A: HTTPS/TLS 1.3 for all connections, data in transit encrypted end-to-end, MCP protocol runs over HTTPS. All connections are encrypted with forward secrecy.

--- a/how-it-works/mcp-architecture.md
+++ b/how-it-works/mcp-architecture.md
@@ -157,9 +157,10 @@ persist across sessions.
   payloads; operational logs retain query text, per-user tool-call metadata,
   and bounded outcome summaries for up to 30 days. Optional indexed search
   has a separate embeddings and minimal-metadata lifecycle.
-- **Revocable at any time.** Disconnect a connector from CorpusIQ's
-  settings panel. The token is deleted immediately. You can also revoke
-  from the vendor's side (Shopify admin, Google account settings, etc.).
+- **Revocable at any time.** Disconnecting a connector commits a durable
+  inactive state before credential cleanup. Cleanup failures are surfaced for
+  retry rather than reported as successful deletion. You can also revoke from
+  the vendor's side (Shopify admin, Google account settings, etc.).
 
 ---
 

--- a/how-it-works/rate-limits-and-quotas.md
+++ b/how-it-works/rate-limits-and-quotas.md
@@ -39,7 +39,7 @@ These apply to all queries, regardless of connector.
 | **Daily API call limit** | None; instead, rate-limited by second | Not a concern for typical use. |
 | **Historical data retention** | Orders: 6 months (standard); 3 years (Plus) | Ask for recent orders. For older data, you'll get no results. |
 | **Result limit per API call** | 250 records | If you need >250 orders, paginate. CorpusIQ handles this automatically. |
-| **Webhook limits** | Not applicable (CorpusIQ is read-only) | — |
+| **Webhook limits** | No customer-facing webhook event contract is currently published | Use the documented request/response APIs. |
 
 **Optimization:** Asking "Orders from last 30 days" is much faster than "All orders ever."
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -119,7 +119,7 @@ URL: https://www.corpusiq.io/docs/
 
 CorpusIQ is a private AI acceleration layer that connects 40+ business tools to ChatGPT, Claude, and Perplexity via the Model Context Protocol (MCP). One question. Cited answers from all your tools.
 
-CorpusIQ acts as a read-only bridge between your SaaS applications and AI assistants. Direct MCP requests retrieve source records live without retaining raw customer files or full connector response payloads. Operational query text, tool-call metadata, and bounded outcome summaries are retained for up to 30 days. Every response includes citations back to the source tool, so you can verify accuracy in one click.
+CorpusIQ provides read-only external-source retrieval between authorized SaaS applications and AI assistants. Explicit CorpusIQ control-plane tools that update or remove user-declared state are separately annotated. Direct MCP requests retrieve source records live without retaining raw customer files or full connector response payloads. Operational query text, tool-call metadata, and bounded outcome summaries are retained for up to 30 days. Every response includes citations back to the source tool, so you can verify accuracy in one click.
 
 ## Key Capabilities
 
@@ -2419,7 +2419,7 @@ Your backend forwards authenticated user requests to CorpusIQ. The API token nev
 
 ### Token Revocation
 
-Tokens can be revoked at any time from the Dashboard (**Settings → API → Revoke All Tokens**). Revocation takes effect immediately across all active sessions. If a token is compromised, revoke it and generate a new one.
+Tokens can be revoked from the Dashboard (**Settings → API → Revoke All Tokens**). The service commits an inactive state before credential cleanup and surfaces cleanup failures for retry. If a token is compromised, revoke it through CorpusIQ and the provider, then generate a new one.
 
 ## Header Reference
 
@@ -2455,7 +2455,7 @@ A: API tokens expire after 60 minutes with server-side refresh detection. Use re
 A: AI agents use OAuth 2.0 Device Authorization Grant (RFC 8628). The agent receives a device code, you verify once via browser, and the agent gets a persistent refresh token  --  no browser needed for ongoing access.
 
 **Q: How do I revoke a CorpusIQ API token?**  
-A: Revoke tokens immediately from the CorpusIQ Dashboard. Revocation takes effect across active sessions. To request deletion of account data, contact privacy@corpusiq.io; CorpusIQ responds to privacy requests within 30 days.
+A: Disconnect the connector from the CorpusIQ Dashboard. The service commits an inactive state before credential cleanup and surfaces cleanup failures for retry; provider-side revocation is also available through the source platform. To request deletion of account data, contact privacy@corpusiq.io; CorpusIQ responds to privacy requests within 30 days.
 
 ## Internal Links
 
@@ -3664,7 +3664,7 @@ The [demo.corpusiq.io](https://demo.corpusiq.io) chat interface is a web applica
 ## Frequently Asked Questions
 
 **Q: What is the CorpusIQ system architecture?**  
-A: CorpusIQ uses a three-layer architecture: AI clients (Claude, ChatGPT, Cursor) connect via MCP protocol to the CorpusIQ MCP endpoint, which routes queries through the connector layer to 36+ business data sources. All access is read-only via OAuth 2.0.
+A: CorpusIQ uses a three-layer architecture: AI clients (Claude, ChatGPT, Cursor) connect via MCP protocol to the CorpusIQ MCP endpoint, which routes queries through the connector layer to business data sources. External-source retrieval uses documented OAuth scopes and does not write back to vendor systems; explicit CorpusIQ control-plane writes are separately annotated.
 
 **Q: How does data flow through CorpusIQ?**  
 A: AI agent sends query via MCP → MCP endpoint authenticates request → Tool registry maps query to connectors → Connector retrieves data from source API → Data is normalized and returned → Agent presents answer to user. All steps are logged for audit.
@@ -6284,7 +6284,7 @@ Yes. Claude's outputs include methodology descriptions, data source citations, a
 CorpusIQ uses a read-only Shopify connection and encrypted transport. Data handling inside Claude follows the terms and settings of the Anthropic plan you choose; review Anthropic's current policy before sending sensitive store data.
 
 ### Can Claude make changes to my Shopify store?
-No. The Shopify connection through CorpusIQ is read-only. Claude can analyze data and make strategic recommendations, but it cannot execute changes in your Shopify admin  --  no product modifications, order changes, or setting adjustments. Human implementation is always required.
+No. The Shopify connector uses read-only vendor retrieval. Claude can analyze data and make strategic recommendations, but it cannot execute changes in your Shopify admin  --  no product modifications, order changes, or setting adjustments. Human implementation is always required.
 
 ### What types of analysis is Claude best for?
 Claude excels at: multi-year trend analysis, full customer base analysis, product portfolio optimization, complex cohort modeling, inventory optimization at scale, attribution modeling, competitive analysis, strategic planning, and any analysis requiring sustained reasoning across large datasets.
@@ -7564,7 +7564,7 @@ This page covers the architecture, what you can ask, enterprise security, and ho
 <details>
 <summary><strong>What NetSuite data can ChatGPT access?</strong></summary>
 
-CorpusIQ's NetSuite integration provides access to core ERP objects: sales orders, customers, invoices, inventory, items, financial reports, and project data. ChatGPT can retrieve individual records, list records with filters, and aggregate data across objects. All access is read-only  --  no record creation, editing, or deletion.
+CorpusIQ's NetSuite integration provides access to core ERP objects: sales orders, customers, invoices, inventory, items, financial reports, and project data. ChatGPT can retrieve individual records, list records with filters, and aggregate data across objects. NetSuite connector retrieval is read-only  --  no record creation, editing, or deletion in that source.
 </details>
 
 <details>
@@ -8572,7 +8572,7 @@ This page covers the architecture, what you can ask, enterprise security conside
 <details>
 <summary><strong>What Salesforce data can ChatGPT access?</strong></summary>
 
-CorpusIQ provides MCP tools that map to core Salesforce objects: Accounts, Contacts, Leads, Opportunities, Cases, and custom objects. ChatGPT can search across these objects, retrieve individual records, list records with filters, and combine data across multiple objects. All access is read-only  --  no create, update, or delete operations exist.
+CorpusIQ provides MCP tools that map to core Salesforce objects: Accounts, Contacts, Leads, Opportunities, Cases, and custom objects. ChatGPT can search across these objects, retrieve individual records, list records with filters, and combine data across multiple objects. Salesforce connector retrieval is read-only  --  no create, update, or delete operations exist for that source.
 </details>
 
 <details>
@@ -11125,7 +11125,7 @@ Every answer reflects the current state of your systems. There's no batch window
 Zapier connects to 7,000+ apps, far more than CorpusIQ's 40+ connectors. For niche tools, Zapier is likely to have an integration.
 
 ### 2. Write Capabilities
-Zapier can create, update, and delete data across apps. CorpusIQ is read-only by design. If you need to automate record creation  --  e.g., "When a Typeform submission comes in, create a HubSpot contact"  --  Zapier is the tool.
+Zapier can create, update, and delete data across apps. CorpusIQ external-source connector tools use read-only retrieval and do not write records back to those apps; its separately annotated control-plane tools operate on user-declared CorpusIQ state. If you need to automate vendor-record creation  --  e.g., "When a Typeform submission comes in, create a HubSpot contact"  --  Zapier is the tool.
 
 ### 3. Multi-Step Logic
 Zapier supports branching paths, filters, delays, and conditional logic within workflows. Complex automations with decision trees are Zapier's strength.
@@ -11263,19 +11263,19 @@ CorpusIQ's enterprise AI data access architecture is built on five pillars:
 
 **Per-user OAuth scoping.** When a user connects a data source through OAuth, the scopes granted are the minimum necessary for read-only business intelligence. Each user authenticates individually  --  there are no shared service accounts that would obscure who accessed what data.
 
-### 2. Read-Only by Default Architecture
+### 2. Read-Only External Retrieval with Explicit Control-Plane Writes
 
-The most important security property of CorpusIQ's enterprise AI data access layer is that it is read-only by default. This is enforced at multiple levels:
+CorpusIQ separates external-source retrieval from writes to user-declared CorpusIQ control-plane state. The boundary is enforced at multiple levels:
 
-- **Protocol level.** MCP tool definitions are registered as read-only. The AI model cannot call a "create" or "update" operation because those tools are not exposed.
+- **Protocol level.** External-source retrieval tools carry read-only annotations. Explicit control-plane tools that update or remove user-declared facts, decisions, metric specifications, and source manifests carry separate non-read-only and destructive annotations where applicable.
 
-- **OAuth scope level.** Connectors request read-only scopes. For QuickBooks, `com.intuit.quickbooks.accounting.read`. For Shopify, `read_orders`, `read_products`, `read_customers`. For HubSpot, read-only access to contacts, deals, and companies.
+- **OAuth scope level.** External-source connectors request the documented retrieval scopes. For QuickBooks, `com.intuit.quickbooks.accounting.read`. For Shopify, `read_orders`, `read_products`, `read_customers`. For HubSpot, read-only access to contacts, deals, and companies.
 
-- **Connector level.** Even if broader OAuth scopes were granted, CorpusIQ's connector implementations validate operations against a capability matrix and block write operations.
+- **Connector level.** External-source connector implementations validate operations against a capability matrix and block write-back operations to connected vendor systems.
 
-- **AI model level.** The tool descriptions the AI model sees describe read-only capabilities  --  "List Salesforce Opportunities" not "Create Salesforce Opportunity."
+- **AI model level.** External connector descriptions identify retrieval behavior, while CorpusIQ control-plane descriptions state the supported state mutation explicitly.
 
-This defense-in-depth approach means that accidental data modification is architecturally impossible. The system cannot write data unless an administrator explicitly enables write operations at all four levels  --  a deliberate, multi-step process that creates an audit trail at each step.
+This defense-in-depth approach prevents external connector tools from writing back to connected vendor systems. Supported CorpusIQ control-plane mutations remain explicit, user-invoked, separately annotated, and auditable.
 
 ### 3. Comprehensive Audit Trails
 
@@ -12441,7 +12441,7 @@ A: Traditional dashboards show predefined views. This answers ANY question in re
 A: Yes. Each executive can have their own CorpusIQ account or share a team account.
 
 **Q: How secure is executive data?**  
-A: CorpusIQ is read-only and inherits source permissions. Financial data in QuickBooks is only visible to users authorized in QuickBooks.
+A: CorpusIQ external-source retrieval is read-only and inherits source permissions. Financial data in QuickBooks is only visible to users authorized in QuickBooks. Separately annotated CorpusIQ control-plane tools operate on user-declared CorpusIQ state.
 
 **Q: Can I get alerts when metrics cross thresholds?**  
 A: Not natively  --  CorpusIQ is query-on-demand. You can set up reminders to check key metrics at regular intervals.
@@ -14439,7 +14439,7 @@ A: CorpusIQ uses MCP (Model Context Protocol)  --  an open standard that lets AI
 A: CorpusIQ supports 40+ business tools including HubSpot, Salesforce, QuickBooks, Stripe, Shopify, GA4, Google Ads, Meta Ads, Slack, Gmail, Google Drive, Notion, PostgreSQL, MSSQL, MongoDB, and more  --  see the full connectors directory.
 
 **Q: Is my data secure with CorpusIQ?**  
-A: Yes. CorpusIQ is read-only by default, does not retain raw customer files or full connector response payloads, uses TLS 1.3 encryption, and is SOC 2 aligned. Operational query and audit logs are retained for up to 30 days. All data source connections use OAuth with minimum required scopes.
+A: Yes. External-source connector tools use read-only retrieval, while explicit CorpusIQ control-plane tools are separately annotated. Direct MCP does not retain raw customer files or full connector response payloads, uses TLS encryption, and follows a SOC 2 aligned posture. Operational query and audit logs are retained for up to 30 days. Data-source connections use documented OAuth scopes.
 
 **Q: How quickly can I start using CorpusIQ?**  
 A: Sign up at corpusiq.io, connect your first data source via OAuth (60 seconds), and start asking natural-language questions. Full setup takes under 5 minutes. See the Quick Start guide for step-by-step instructions.
@@ -16330,7 +16330,7 @@ With these five categories connected, a small business owner can answer virtuall
 
 **Self-service onboarding.** No implementation calls, no consulting engagements. The setup is designed to be completed by a business owner, not an IT team.
 
-**Read-only safety.** Small business owners can connect their financial systems without worrying about the AI accidentally modifying data. Read-only defaults mean zero risk of unintended changes.
+**Read-only external retrieval.** Small business owners can query connected financial systems without the connector tools writing back to those vendor records. Explicit CorpusIQ control-plane changes are separately annotated.
 
 **Mobile-friendly queries.** Ask questions from your phone through any MCP-compatible AI client. Check business health during your morning coffee without opening a laptop.
 
@@ -16351,7 +16351,7 @@ CorpusIQ offers plans starting at accessible SMB price points. Visit the CorpusI
 <details>
 <summary><strong>Is my data secure? Can the AI accidentally delete something?</strong></summary>
 
-CorpusIQ defaults to read-only access for all connectors. The AI cannot modify, delete, or create data. It can only read and report. For small businesses, this means zero risk of the AI making unintended changes to your QuickBooks or Shopify data.
+CorpusIQ external-source connector tools use read-only retrieval and do not modify, delete, or create records in connected vendor systems such as QuickBooks or Shopify. Explicit CorpusIQ control-plane tools operate only on user-declared CorpusIQ state and carry separate safety annotations.
 </details>
 
 <details>
@@ -16436,7 +16436,7 @@ OAuth tokens are the keys to your data. Managing them securely is critical:
 
 **Automatic token rotation.** When a refresh token is used to obtain a new access token, some providers also rotate the refresh token. CorpusIQ handles this rotation transparently, ensuring the latest refresh token is always stored.
 
-**Token revocation.** Users can revoke access to any connected platform at any time through the CorpusIQ dashboard. Revocation immediately deletes all stored tokens for that platform and terminates any in-flight requests.
+**Token revocation.** Users can disconnect a connected platform through the CorpusIQ dashboard. The service commits an inactive state before credential cleanup; cleanup failures are surfaced for retry rather than reported as successful deletion. Provider-side revocation remains available through the connected platform.
 
 **Cross-user isolation.** Each user's tokens are cryptographically isolated. User A's Shopify token cannot be used to access User B's data, even if both users are in the same CorpusIQ organization. This isolation extends to the database layer  --  tokens are stored with user-scoped encryption keys.
 
@@ -16539,12 +16539,6 @@ To request deletion of account data, contact privacy@corpusiq.io. CorpusIQ respo
 <summary><strong>How do you prevent AI models from leaking data across customers?</strong></summary>
 
 Each query is processed in isolation. The AI model receives only the data from the current user's query. CorpusIQ does not use customer data to train or fine-tune models; conversation handling follows the selected AI provider's plan and settings.
-</details>
-
-<details>
-<summary><strong>Can I use CorpusIQ with on-premise data sources?</strong></summary>
-
-Yes. MCP servers can be deployed on-premise and connect to internal systems. If both the MCP server and AI client run inside your network, provider data can remain within that boundary; otherwise the chosen AI client's processing path and retention policy also apply.
 </details>
 
 [Content truncated; see the canonical page for the complete text.]
@@ -18313,7 +18307,7 @@ CorpusIQ uses HTTPS/TLS for data in transit and Azure-managed encryption for per
 CorpusIQ sits between your tools and the AI assistant. It sends the requesting AI client the source data needed for the requested tool result and citations; it does not give the model persistent provider access. Direct MCP requests do not build embeddings or file indexes.
 
 ### Can CorpusIQ modify my data?
-External source connectors are designed for read-only retrieval and do not write back to those connected vendor systems. CorpusIQ control-plane tools can update user-declared CorpusIQ state or revoke credentials when the user explicitly requests those actions. Review the exact vendor scopes on each OAuth authorization screen and the safety annotations on the selected tool.
+External source connectors are designed for read-only retrieval and do not write back to those connected vendor systems. Explicit CorpusIQ control-plane tools can update or remove user-declared facts, decisions, metric specifications, and source manifests when the user requests those actions. Review the exact vendor scopes on each OAuth authorization screen and the safety annotations on the selected tool.
 
 ### What encryption standards does CorpusIQ use?
 CorpusIQ uses HTTPS/TLS for data in transit and the encryption-at-rest controls of its managed Azure services. Customer-specific requirements for keys, rotation, residency, backups, or dedicated infrastructure should be validated during an enterprise security review rather than inferred from this overview.
@@ -18349,7 +18343,7 @@ AI Assistant → CorpusIQ MCP Server → HTTPS/TLS → Scoped OAuth → Business
 ## Benefits
 
 ### Read-Only External Retrieval
-External source connectors are designed not to write back to connected vendor systems. CorpusIQ control-plane operations, including credential revocation and user-declared state changes, remain explicit and separately annotated.
+External source connectors are designed not to write back to connected vendor systems. CorpusIQ control-plane operations that update or remove user-declared facts, decisions, metric specifications, and source manifests remain explicit and separately annotated.
 
 ### Scoped Data Handling
 Direct MCP requests use live retrieval without retaining raw customer files or full connector response payloads. Operational query logs are retained for up to 30 days. Optional indexed-search features have a separate embeddings-and-metadata lifecycle.
@@ -18441,7 +18435,7 @@ robots: "index,follow"
 ---
 # Security
 
-CorpusIQ is designed with security as a foundational requirement. All access is read-only. We never write to your systems.
+CorpusIQ is designed with security as a foundational requirement. External-source connector access is read-only and does not write back to vendor systems. Explicit CorpusIQ control-plane tools can update or remove user-declared CorpusIQ state and carry separate safety annotations.
 
 ## Authentication
 
@@ -18465,12 +18459,8 @@ CorpusIQ is designed with security as a foundational requirement. All access is 
 
 ## Data Access
 
-### Read-Only Policy
-CorpusIQ is strictly read-only. We:
-- Query data from your connected sources
-- Normalize and present results
-- Never write, modify, or delete data
-- Never initiate transactions or changes
+### Scoped Access Policy
+External-source connector tools use read-only retrieval: they query connected sources, normalize results, and do not write back to those vendor systems or initiate vendor transactions. Explicit CorpusIQ control-plane tools can update or remove user-declared facts, decisions, metric specifications, and source manifests and carry separate safety annotations.
 
 ### Data Handling
 - Direct MCP retrieves source records on demand and delivers scoped results to the requesting client
@@ -18508,8 +18498,8 @@ Report security concerns to security@corpusiq.io. We respond within 24 hours.
 **Q: How does CorpusIQ authenticate users?**  
 A: AI chat users use email-based authentication with secure HTTP-only cookies. AI agent users use OAuth 2.0 Device Authorization Grant (RFC 8628) with refresh token rotation. Data source connections use OAuth 2.0 with scoped, read-only permissions.
 
-**Q: Is CorpusIQ data access read-only?**  
-A: Yes. CorpusIQ is strictly read-only. It queries data from connected sources, normalizes and presents results, but never writes, modifies, or deletes data, and never initiates transactions or changes.
+**Q: Is CorpusIQ data access read-only?**
+A: External-source retrieval is read-only and does not write back to connected vendor systems. Explicit CorpusIQ control-plane tools can modify user-declared CorpusIQ state and are separately annotated.
 
 **Q: What encryption does CorpusIQ use?**  
 A: HTTPS/TLS 1.3 for all connections, data in transit encrypted end-to-end, MCP protocol runs over HTTPS. All connections are encrypted with forward secrecy.
@@ -18548,7 +18538,7 @@ CorpusIQ is designed with data privacy as a foundational principle. This page do
 | **SOC 2** | Aligned  --  formal certification is not claimed; controls are reviewed quarterly |
 | **GDPR** | Aligned  --  data minimization, user consent, deletion rights |
 | **Encryption** | AES-256 at rest, TLS 1.3 in transit |
-| **Access Model** | Read-only OAuth  --  no write permissions ever |
+| **Access Model** | Read-only external-source retrieval; explicit CorpusIQ control-plane writes are separately annotated |
 
 Contact: security@corpusiq.io · privacy@corpusiq.io
 
@@ -18589,10 +18579,10 @@ AES-256, managed keys, key rotation every 90 days.
 Private subnets, deny-by-default, WAF and rate limits on all public endpoints.
 
 ### Access
-Read-only OAuth scopes only. No write permissions on any connector. The specific scopes requested are visible on the OAuth authorization screen during connection setup.
+External-source connectors use the documented retrieval scopes and do not write back to vendor systems. Explicit CorpusIQ control-plane tools that mutate user-declared CorpusIQ state are separately annotated. Vendor scopes remain visible on the OAuth authorization screen during connection setup.
 
 ### Authentication
-API tokens have 60-minute expiry with server-side refresh detection. Tokens are never embedded in client-side code  --  server-side usage only. Token revocation takes effect immediately across all active sessions.
+API tokens have 60-minute expiry with server-side refresh detection. Tokens are never embedded in client-side code  --  server-side usage only. Disconnect commits an inactive state before credential cleanup; cleanup failures are surfaced for retry.
 
 ### Webhook Security
 CorpusIQ does not currently publish a customer-facing webhook event contract. Event schemas, authentication, and delivery guarantees will be documented only after their production routes are verified.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,15 @@
 edit_uri: edit/main/docs/
+# This repository still contains legacy prebuilt HTML/search artifacts from an
+# older deployment model. Publishing them alongside Markdown causes MkDocs to
+# prefer stale `api/foo.html` files over current `api/foo.md` pages. Exclude all
+# generated HTML and the generated root search index; keep only intentional
+# first-party email templates that are distributed as raw HTML examples.
+exclude_docs: |
+  *.html
+  **/*.html
+  !hermes/templates/*.html
+  !community/tokens-saved-widget.html
+  search/search_index.json
 extra_css:
 - stylesheets/extra-v2.css
 extra_javascript:

--- a/recipes/morning-briefing.md
+++ b/recipes/morning-briefing.md
@@ -23,7 +23,7 @@ Your AI queries all five tools, pulls the numbers, compares against the previous
 ## Setup
 
 1. Connect your daily-check tools in CorpusIQ
-2. Read-only OAuth for all. Your AI reads data, never modifies.
+2. Use the connectors' read-only external-source retrieval. Your AI can read the briefing data without writing back to those vendor systems.
 3. Ask your morning question.
 
 ## Example briefing

--- a/scripts/retention_claim_probe_matrix.json
+++ b/scripts/retention_claim_probe_matrix.json
@@ -52,6 +52,88 @@
         "text": "CorpusIQ secures the integration with HMAC signatures."
       }
     ],
+    "surface_scope": [
+      {
+        "label": "every_connector_read_only",
+        "text": "Every connector is read-only."
+      },
+      {
+        "label": "whole_product_read_only_abstraction",
+        "text": "CorpusIQ provides a read-only abstraction layer."
+      },
+      {
+        "label": "ai_can_only_read",
+        "text": "The AI can only read."
+      },
+      {
+        "label": "no_third_party_transfer",
+        "text": "Your data never goes through any third-party server."
+      },
+      {
+        "label": "unsupported_control_plane_revocation",
+        "text": "CorpusIQ control-plane tools can revoke credentials."
+      },
+      {
+        "label": "whole_product_is_read_only",
+        "text": "CorpusIQ is read-only by default."
+      },
+      {
+        "label": "whole_product_read_only_bridge",
+        "text": "CorpusIQ acts as a read-only bridge."
+      },
+      {
+        "label": "no_data_leaves_control",
+        "text": "No data leaves your control."
+      },
+      {
+        "label": "no_middleman",
+        "text": "Live data flows directly into the AI's response. No middleman."
+      },
+      {
+        "label": "instant_token_deletion",
+        "text": "Revocation immediately deletes all stored tokens."
+      },
+      {
+        "label": "instant_token_revocation_instruction",
+        "text": "Revoke tokens immediately from the dashboard."
+      },
+      {
+        "label": "strictly_read_only_product",
+        "text": "CorpusIQ is strictly read-only."
+      },
+      {
+        "label": "all_connectors_read_only_default",
+        "text": "CorpusIQ defaults to read-only access for all connectors."
+      },
+      {
+        "label": "all_mcp_tools_registered_read_only",
+        "text": "MCP tool definitions are registered as read-only."
+      },
+      {
+        "label": "no_connector_write_permissions",
+        "text": "No write permissions on any connector."
+      },
+      {
+        "label": "architecturally_impossible_modification",
+        "text": "Accidental data modification is architecturally impossible."
+      },
+      {
+        "label": "all_access_read_only",
+        "text": "All access is read-only."
+      },
+      {
+        "label": "no_write_permissions_ever",
+        "text": "Read-only OAuth means no write permissions ever."
+      },
+      {
+        "label": "zero_risk_changes",
+        "text": "Read-only defaults mean zero risk of unintended changes."
+      },
+      {
+        "label": "instant_revocation_sessions",
+        "text": "Revocation takes effect immediately across all active sessions."
+      }
+    ],
     "retention": [
       {
         "label": "review_raw_files_never_stored",
@@ -761,6 +843,18 @@
     {
       "label": "independent_canonical_indexing",
       "text": "Direct MCP does not build embeddings or file indexes; optional indexed search separately retains embeddings and minimal metadata until revocation or account deletion."
+    },
+    {
+      "label": "scoped_external_retrieval",
+      "text": "External-source connector tools use read-only retrieval and do not write back to vendor systems."
+    },
+    {
+      "label": "supported_control_plane_classes",
+      "text": "Explicit CorpusIQ control-plane tools can update or remove user-declared facts, decisions, metric specifications, and source manifests."
+    },
+    {
+      "label": "truthful_transfer_boundary",
+      "text": "Connector results pass through CorpusIQ to the requesting AI client."
     }
   ]
 }

--- a/scripts/validate_retention_claims.py
+++ b/scripts/validate_retention_claims.py
@@ -90,6 +90,56 @@ FORBIDDEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
             re.IGNORECASE,
         ),
     ),
+    (
+        "blanket whole-product read-only claim",
+        re.compile(
+            r"\bevery\s+connector\s+is\s+read[- ]only\b|"
+            r"\bCorpusIQ\s+is\s+read[- ]only(?:\s+by\s+(?:default|design))?\b|"
+            r"\bCorpusIQ\s+(?:acts\s+as|provides)\s+(?:a\s+)?read[- ]only\s+bridge\b|"
+            r"\bCorpusIQ\s+is\s+strictly\s+read[- ]only\b|"
+            r"\bCorpusIQ\s+defaults?\s+to\s+read[- ]only\s+access\s+for\s+all\s+connectors\b|"
+            r"\bMCP\s+tool\s+definitions\s+are\s+registered\s+as\s+read[- ]only\b|"
+            r"\bno\s+write\s+permissions\s+on\s+any\s+connector\b|"
+            r"\ball\s+access\s+is\s+read[- ]only\b|"
+            r"\bno\s+write\s+permissions\s+ever\b|"
+            r"\bzero\s+risk\s+of\s+unintended\s+changes\b|"
+            r"\baccidental\s+data\s+modification\s+is\s+architecturally\s+impossible\b|"
+            r"\bCorpusIQ\s+provides\s+(?:a\s+)?read[- ]only\s+"
+            r"(?:abstraction(?:\s+layer)?|platform|service|system)\b|"
+            r"\b(?:the\s+)?AI\s+can\s+only\s+read\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "unsupported no-transfer claim",
+        re.compile(
+            r"\b(?:your\s+)?data\s+never\s+(?:goes|passes|moves)\s+through\s+"
+            r"(?:a|any|some)\s+third[- ]party\s+server\b|"
+            r"\bno\s+data\s+leaves\s+your\s+control\b|"
+            r"\blive\s+data\s+flows\s+directly\s+into\s+the\s+AI['’]s\s+response\b|"
+            r"\bno\s+middleman\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "unsupported control-plane credential revocation claim",
+        re.compile(
+            r"\b(?:CorpusIQ\s+)?control[- ]plane\b[^.\n]{0,180}"
+            r"\brevok(?:e|es|ed|ing|ation)\s+(?:credentials?|tokens?)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "unsupported immediate credential deletion claim",
+        re.compile(
+            r"\brevocation\s+immediately\s+deletes\s+all\s+stored\s+tokens\b|"
+            r"\brevoke\s+tokens\s+immediately\b|"
+            r"\brevocation\s+takes\s+effect\s+immediately\s+across\s+all\s+active\s+sessions\b|"
+            r"\b(?:the\s+)?token\s+is\s+deleted\s+immediately\b|"
+            r"\bimmediately\s+deletes\s+all\s+stored\s+tokens\b",
+            re.IGNORECASE,
+        ),
+    ),
     ("additional blanket lifecycle claim", ADDITIONAL_BLANKET_PATTERN),
     (
         "zero/no data storage",


### PR DESCRIPTION
## Summary
- prevents stale tracked HTML/search artifacts from shadowing current Markdown in MkDocs
- preserves intentional raw HTML assets (onboarding template and community widget)
- removes unsupported webhook, deletion, residency, immediate-revocation, no-transfer, and whole-product read-only claims
- distinguishes read-only external-source retrieval from separately annotated CorpusIQ control-plane writes
- strengthens semantic validators/probe matrices and regenerates deterministic crawler feeds

## Verification
- validator tests: 11/11 passed
- source/feed corpus scan: passed
- MkDocs build: passed
- intentional HTML assets present and byte-identical
- deterministic feed generation verified
- independent final review: PASS

Follow-up to #93 and CorpusIQ/multi-source-mcp#216.