### PR TITLE
docs: correct public connector security disclosures

### DIFF
--- a/content/blog/connected-business-to-ai.md
+++ b/content/blog/connected-business-to-ai.md
@@ -81,10 +81,10 @@ Five minutes for one connector. Another five for each additional. The time isn't
 
 ## The Bottom Line
 
-I stopped building reports by hand. I just ask the AI. The numbers are always live, always accurate, and I can ask follow-ups without rebuilding anything.
+I stopped building reports by hand. I just ask the AI. The answers cite current source records, and I can ask follow-ups without rebuilding a report. Freshness still follows each provider and CorpusIQ cache behavior.
 
 If you already pay for QuickBooks, Shopify, or Stripe, you have the data. You just couldn't talk to it before. Now you can.
 
 ---
 
-*I run CorpusIQ — the platform that connects business data to AI assistants. 37+ connectors, 5-minute setup, read-only by design. If you want to try this yourself: [corpusiq.io](https://www.corpusiq.io).*
+*I run CorpusIQ — the platform that connects business data to AI assistants. 40+ connectors, 5-minute setup, and separately annotated retrieval, write-capable, and control-plane tools. If you want to try this yourself: [corpusiq.io](https://www.corpusiq.io).*

--- a/content/seo/connect-business-data-to-chatgpt.md
+++ b/content/seo/connect-business-data-to-chatgpt.md
@@ -91,7 +91,7 @@ Each answer draws from live data. No exports. No pivots. No "let me check and ge
 
 ## What about security?
 
-Every connection is read-only. The AI can query your data but cannot modify it. No accidental refunds. No deleted orders. No changed invoices.
+External-source retrieval tools are marked read-only; write-capable connector and CorpusIQ control-plane tools are separately named and annotated. The AI can query your data but cannot modify it. No accidental refunds. No deleted orders. No changed invoices.
 
 Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may persist for up to 30 days. CorpusIQ does not train models on customer data; conversation handling follows the AI-provider plan and settings you choose.
 

--- a/content/seo/mcp-for-ecommerce.md
+++ b/content/seo/mcp-for-ecommerce.md
@@ -93,7 +93,7 @@ The AI queries Shopify for order data, Meta for ad spend and conversions, then c
 
 ## The read-only guarantee
 
-Every connection is read-only. The AI can see your Shopify orders but can't modify them. It can read your Klaviyo campaign stats but can't send an email. It can pull Meta Ads data but can't change your budgets.
+External-source retrieval tools are marked read-only; write-capable connector and CorpusIQ control-plane tools are separately named and annotated. The AI can see your Shopify orders but can't modify them. It can read your Klaviyo campaign stats but can't send an email. It can pull Meta Ads data but can't change your budgets.
 
 This matters because the fear is real: "what if the AI messes something up?" It can't. It can only read. It can only answer.
 

--- a/content/seo/mcp-for-saas-founders.md
+++ b/content/seo/mcp-for-saas-founders.md
@@ -53,7 +53,7 @@ Each answer is live data, cross-referenced across tools. Not a dashboard. Not a 
 
 ## The read-only guarantee
 
-Every connection is read-only. The AI can query Stripe but can't issue a refund. It can pull HubSpot data but can't close a deal. It can read QuickBooks but can't modify a single transaction.
+External-source retrieval tools are marked read-only; write-capable connector and CorpusIQ control-plane tools are separately named and annotated. The AI can query Stripe but can't issue a refund. It can pull HubSpot data but can't close a deal. It can read QuickBooks but can't modify a single transaction.
 
 For founders who've been burned by automation gone wrong, this is the feature that makes it safe.
 

--- a/content/seo/seo-ai-compliance.md
+++ b/content/seo/seo-ai-compliance.md
@@ -22,7 +22,7 @@ Connect your tools. Then ask:
 
 > "Which users accessed financial data this month? Show me the access log."
 
-Every answer: live data from the source system. Complete audit trail. Nothing modified — read-only by design.
+Answers use cited source data. External-source retrieval tools are marked read-only; write-capable and control-plane tools are separately named and annotated.
 
 ---
 

--- a/content/seo/seo-best-ai-data-connector.md
+++ b/content/seo/seo-best-ai-data-connector.md
@@ -4,8 +4,8 @@ You want to connect your business data to an AI assistant. You're comparing plat
 
 ## The 5 questions that matter
 
-**1. Is it read-only?**
-If a connector can write to your QuickBooks or Stripe, it's a liability. The AI should query your data, not modify it. Read-only should be architectural — not a setting you can accidentally toggle.
+**1. Are permissions operation-specific?**
+Retrieval and write operations should be separately named and annotated. A blanket read-only label is not enough.
 
 **2. How many connectors do you actually need?**
 Don't count connectors. Count the ones you'll use. Most businesses need five: accounting (QuickBooks/Xero), payments (Stripe), CRM (HubSpot/Salesforce), ecommerce (Shopify), analytics (GA4). If a platform has those five, it covers 90% of questions.
@@ -23,7 +23,7 @@ Look for live retrieval, disclosed processors, scoped operational retention, and
 
 | Criteria | CorpusIQ |
 |----------|----------|
-| Read-only | Architectural — no write path exists |
+| Permissions | Retrieval tools marked read-only; write-capable and control-plane tools separately annotated |
 | Core connectors | All five + 32 more |
 | Cross-tool queries | Native — ask across any combination |
 | AI compatibility | ChatGPT, Claude, Perplexity, any MCP client |
@@ -33,4 +33,4 @@ Look for live retrieval, disclosed processors, scoped operational retention, and
 
 ---
 
-*CorpusIQ: 37+ connectors. Read-only. Cross-tool queries built in. [corpusiq.io](https://www.corpusiq.io)*
+*CorpusIQ: 40+ connectors, operation-level permissions, and cross-tool queries. [corpusiq.io](https://www.corpusiq.io)*

--- a/content/seo/seo-chatgpt-stripe.md
+++ b/content/seo/seo-chatgpt-stripe.md
@@ -8,7 +8,7 @@ ChatGPT can query your real Stripe data. MRR, revenue, churn, customers — live
 
 > "Show me revenue by plan. Which plans drive the most growth?"
 
-Setup: corpusiq.io → Connect Stripe (read-only OAuth, 30s) → Add MCP config → Ask.
+Setup: corpusiq.io → Connect Stripe (read-only external-source retrieval, 30s) → Add MCP config → Ask.
 
 ---
 

--- a/content/seo/seo-claude-quickbooks.md
+++ b/content/seo/seo-claude-quickbooks.md
@@ -8,7 +8,7 @@ Claude can query your real QuickBooks data. P&L, invoices, expenses, AR aging �
 
 > "What's our cash runway at current burn rate?"
 
-Setup: corpusiq.io → Connect QuickBooks (read-only OAuth, 30s) → Add MCP config → Ask Claude.
+Setup: corpusiq.io → Connect QuickBooks (read-only external-source retrieval, 30s) → Add MCP config → Ask Claude.
 
 ---
 

--- a/content/seo/seo-connect-drive-chatgpt.md
+++ b/content/seo/seo-connect-drive-chatgpt.md
@@ -10,7 +10,7 @@ Connect Google Drive to ChatGPT and ask:
 
 > "What contracts are expiring this quarter? Find them in Drive."
 
-Setup: corpusiq.io → Connect Google Drive (read-only OAuth) → ChatGPT → Ask.
+Setup: corpusiq.io → Connect Google Drive (read-only external-source retrieval) → ChatGPT → Ask.
 
 ---
 

--- a/content/seo/seo-connect-gmail-claude.md
+++ b/content/seo/seo-connect-gmail-claude.md
@@ -10,7 +10,7 @@ Connect Gmail to Claude and ask:
 
 > "Which clients haven't been contacted in 30 days?"
 
-Setup: corpusiq.io → Connect Gmail (read-only OAuth, 30s) → Add MCP config → Ask Claude.
+Setup: corpusiq.io → Connect Gmail (read-only external-source retrieval, 30s) → Add MCP config → Ask Claude.
 
 ---
 

--- a/content/seo/seo-connect-netsuite-claude.md
+++ b/content/seo/seo-connect-netsuite-claude.md
@@ -10,7 +10,7 @@ Connect NetSuite to Claude and ask:
 
 > "What's our order backlog? Which customers are waiting?"
 
-Setup: corpusiq.io → Connect NetSuite (read-only OAuth) → Claude → Ask.
+Setup: corpusiq.io → Connect NetSuite (read-only external-source retrieval) → Claude → Ask.
 
 ---
 

--- a/content/seo/seo-connect-salesforce-chatgpt.md
+++ b/content/seo/seo-connect-salesforce-chatgpt.md
@@ -10,7 +10,7 @@ Connect Salesforce to ChatGPT and ask:
 
 > "Which accounts haven't had activity in 30 days? Rank by ARR."
 
-Setup: corpusiq.io → Connect Salesforce (read-only OAuth) → ChatGPT → Ask.
+Setup: corpusiq.io → Connect Salesforce (read-only external-source retrieval) → ChatGPT → Ask.
 
 ---
 

--- a/content/seo/seo-connect-sheets-chatgpt.md
+++ b/content/seo/seo-connect-sheets-chatgpt.md
@@ -10,7 +10,7 @@ Connect Google Sheets to ChatGPT and ask:
 
 > "What's the average deal size by sales rep? Who's above the team average?"
 
-Setup: corpusiq.io → Connect Google Sheets (read-only OAuth) → ChatGPT → Ask.
+Setup: corpusiq.io → Connect Google Sheets (read-only external-source retrieval) → ChatGPT → Ask.
 
 ---
 

--- a/content/seo/seo-enterprise-ai-data-access.md
+++ b/content/seo/seo-enterprise-ai-data-access.md
@@ -9,16 +9,16 @@ Enterprise IT wants to enable AI access to business data. They also need to:
 - Prevent unauthorized data access
 - Maintain audit trails
 - Comply with SOC 2, GDPR, CCPA
-- Keep data in-region
+- Review each processor and deployment region
 - Avoid creating new attack surfaces
 
 Traditional approach: 6-month security review, custom API build, data warehouse copy, restricted access. By the time it's ready, the business has moved on.
 
 ## How MCP satisfies both sides
 
-**Read-only by design:** No write path exists. The AI cannot modify data. This eliminates the #1 security concern.
+**Operation-level permissions:** External-source retrieval tools are marked read-only; write-capable and control-plane tools are separately named and annotated.
 
-**OAuth-native, per-user:** Each user authenticates individually. No shared credentials. Instant revoke. Full audit trail of who queried what.
+**Provider-specific authentication:** OAuth is used where supported; other connectors use encrypted credentials or restricted roles. Provider-side revocation remains provider-governed.
 
 **Scoped retention:** Direct MCP queries sources live without retaining raw customer files or full connector response payloads. Operational logs may persist for up to 30 days; optional indexed search and compliance receipts follow separate lifecycles.
 
@@ -28,14 +28,14 @@ Traditional approach: 6-month security review, custom API build, data warehouse 
 
 | Requirement | MCP Solution |
 |------------|-------------|
-| Read-only access | Architectural guarantee |
-| Per-user auth | OAuth, instant revoke |
+| Operation permissions | Retrieval, write-capable, and control-plane operations separately annotated |
+| Authentication | Provider-specific OAuth, encrypted credentials, or restricted roles |
 | Audit trail | Query logging by user |
 | Data residency | Source remains authoritative; CorpusIQ and AI-provider processing paths require separate review |
-| Smaller retained-data surface | No raw-file or full-payload warehouse; scoped operational logs |
+| Smaller retained-data surface | Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may persist |
 | Compliance | SOC 2 aligned; CASA Tier 2 certified by DEKRA |
 | SSO | Enterprise identity provider |
 
 ---
 
-*CorpusIQ: Enterprise AI data access. SOC 2 aligned and CASA Tier 2 certified. Read-only by design. [corpusiq.io](https://www.corpusiq.io)*
+*CorpusIQ: Enterprise AI data access with operation-level permissions, SOC 2 aligned controls, and CASA Tier 2 certification. [corpusiq.io](https://www.corpusiq.io)*

--- a/content/seo/seo-executive-ai-dashboard.md
+++ b/content/seo/seo-executive-ai-dashboard.md
@@ -30,7 +30,7 @@ Each answer draws from live data. Each follow-up question gets an instant answer
 
 **Depth:** Executives ask follow-up questions instead of accepting surface-level data.
 
-**Accuracy:** No more "the dashboard says X but I think it's actually Y" because the data is always live.
+**Verifiability:** Answers cite source records so leaders can check time-sensitive figures against the originating system.
 
 **Adoption:** Everyone uses it because it answers real questions, not pre-built ones.
 

--- a/content/seo/seo-how-mcp-servers-work.md
+++ b/content/seo/seo-how-mcp-servers-work.md
@@ -40,7 +40,7 @@ MCP uses JSON-RPC over Streamable HTTP. Every interaction follows the same patte
 | **Discovery** | Hard-code tool definitions | Auto-discovered by client |
 | **Maintenance** | Update when APIs change | Server handles updates |
 | **Cross-tool** | Write custom join logic | Multiple tools, one protocol |
-| **Security** | Keys can leak, be misused | OAuth scopes, read-only possible |
+| **Security** | Keys can leak or be misused | Operation-level annotations and provider-specific authentication |
 
 ## One server, many tools
 

--- a/content/seo/seo-hubspot-ai-reporting.md
+++ b/content/seo/seo-hubspot-ai-reporting.md
@@ -14,7 +14,7 @@ AI-powered HubSpot reporting means asking:
 
 Connect HubSpot to AI via MCP. Live pipeline data. Instant answers.
 
-Setup: corpusiq.io → HubSpot (read-only OAuth, 30s) → ChatGPT/Claude → Ask.
+Setup: corpusiq.io → HubSpot (read-only external-source retrieval, 30s) → ChatGPT/Claude → Ask.
 
 ---
 

--- a/content/seo/seo-mcp-for-accountants.md
+++ b/content/seo/seo-mcp-for-accountants.md
@@ -46,7 +46,7 @@ Each answer takes 15 seconds instead of 30 minutes.
 
 ## Read-only means safe
 
-Every connection is read-only. The AI can query QuickBooks but cannot create a transaction, modify an entry, or change a single number.
+External-source retrieval tools are marked read-only; write-capable connector and CorpusIQ control-plane tools are separately named and annotated. The AI can query QuickBooks but cannot create a transaction, modify an entry, or change a single number.
 
 For accountants who handle sensitive financial data, this is non-negotiable. And it's built in from the start.
 

--- a/content/seo/seo-mcp-for-finance.md
+++ b/content/seo/seo-mcp-for-finance.md
@@ -40,7 +40,7 @@ Each answer: 15 seconds. The whole close: 30 minutes instead of 3 days.
 
 ## Read-only means audit-safe
 
-Every connection is read-only. The AI can query QuickBooks but cannot create a journal entry. It can pull Stripe data but cannot issue a refund. It can check HubSpot but cannot modify a deal.
+External-source retrieval tools are marked read-only; write-capable connector and CorpusIQ control-plane tools are separately named and annotated. The AI can query QuickBooks but cannot create a journal entry. It can pull Stripe data but cannot issue a refund. It can check HubSpot but cannot modify a deal.
 
 For finance teams handling SOX compliance or external audits, this is non-negotiable. The connector reads without writing back to the source. Operational query text, per-user tool-call metadata, and bounded outcome summaries may remain for up to 30 days; deletion and compliance receipts may remain for up to 24 months.
 

--- a/content/seo/seo-mcp-for-hr.md
+++ b/content/seo/seo-mcp-for-hr.md
@@ -37,7 +37,7 @@ Connect your HR tools. Then ask:
 
 ## The read-only guarantee
 
-Every connection is read-only. The AI can query headcount data but cannot modify employee records. It can pull compensation data but cannot change salaries. HR data is sensitive — read-only access is non-negotiable.
+External-source retrieval tools are marked read-only; write-capable connector and CorpusIQ control-plane tools are separately named and annotated. The AI can query headcount data but cannot modify employee records. It can pull compensation data but cannot change salaries. HR data is sensitive — read-only access is non-negotiable.
 
 ---
 

--- a/content/seo/seo-mcp-for-marketing.md
+++ b/content/seo/seo-mcp-for-marketing.md
@@ -60,7 +60,7 @@ Each answer: 15 seconds. Live data from every connected platform. No spreadsheet
 
 ## The read-only guarantee
 
-Every connection is read-only. The AI can query your ad accounts but can't change budgets, pause campaigns, or modify anything. It reads and answers. That's it.
+External-source retrieval tools are marked read-only; write-capable connector and CorpusIQ control-plane tools are separately named and annotated. The AI can query your ad accounts but can't change budgets, pause campaigns, or modify anything. It reads and answers. That's it.
 
 ## What marketing teams tell us
 

--- a/content/seo/seo-mcp-for-supply-chain.md
+++ b/content/seo/seo-mcp-for-supply-chain.md
@@ -32,7 +32,7 @@ Connect your tools. Then ask:
 
 ## Read-only means safe
 
-Every connection is read-only. The AI can query inventory levels but can't create POs. It can check order status but can't modify shipments. You stay in control.
+External-source retrieval tools are marked read-only; write-capable connector and CorpusIQ control-plane tools are separately named and annotated. The AI can query inventory levels but can't create POs. It can check order status but can't modify shipments. You stay in control.
 
 ---
 

--- a/content/seo/seo-secure-ai-connectivity.md
+++ b/content/seo/seo-secure-ai-connectivity.md
@@ -1,42 +1,42 @@
-# Secure AI Data Connectivity — Read-Only Changes Everything
+# Secure AI Data Connectivity — Operation-Level Permissions
 
-The #1 objection to connecting business data to AI: "What if it messes something up?"
+The first question when connecting business data to AI is reasonable: "What can each tool change?"
 
-Fair question. Here's why read-only design makes that impossible — and what else you should look for.
+The honest answer belongs in each advertised operation's permissions, not in one product-wide slogan.
 
-## The read-only guarantee
+## The permission model
 
-Every CorpusIQ connector is read-only by design. The AI can query your QuickBooks P&L but cannot create a transaction. It can pull Stripe charges but cannot issue a refund. It can search HubSpot but cannot modify a deal.
+CorpusIQ marks external-source retrieval tools read-only. Write-capable connector operations and CorpusIQ control-plane tools are separately named and annotated so clients and reviewers can distinguish retrieval from mutation.
 
-This isn't a setting you can accidentally change. It's architectural. The OAuth scopes only request read access. The API calls only use GET methods. There is no write path.
+Provider authorization varies by connector. OAuth is used where supported; other connectors use encrypted credentials or restricted roles. The effective permission remains bounded by both the provider grant and the specific advertised tool.
 
 ## What else matters for security
 
-**OAuth-native authentication:** No API keys to manage, rotate, or leak. Each user authenticates via their own OAuth flow. Revoke access instantly from your Google/QuickBooks/admin console.
+**Provider authentication:** CorpusIQ uses provider OAuth where supported and stores required credential-based connector secrets encrypted. Manage provider authorization through the relevant provider controls; provider-side timing follows each provider's lifecycle.
 
 **Scoped retention:** Direct MCP does not retain raw customer files or full connector response payloads; operational logs may persist for up to 30 days.
 
 **Disclosed processors:** CorpusIQ runs on Microsoft Azure and uses the selected AI client to answer the request. Each provider's published data policy applies to its part of the flow.
 
-**CASA Tier 2 certified:** Independent security certification verifying read-only access controls, OAuth security, and data handling practices.
+**CASA Tier 2 certified:** CorpusIQ completed the DEKRA-assessed CASA Tier 2 process. The certification does not replace operation-level permission review.
 
-**SOC 2 aligned:** Security controls mapped to the framework; formal SOC 2 Type II certification is not claimed.
+**SOC 2 aligned:** Security controls are mapped to the framework; formal SOC 2 Type II certification is not claimed.
 
 ## The questions to ask any AI data platform
 
 | Question | Why it matters |
 |----------|---------------|
-| Is it read-only by default? | Can't accidentally modify your data |
-| Where does my data go? | Should flow directly to AI, not stored |
-| How is auth handled? | OAuth > API keys. Per-user > shared. |
-| Is it independently audited? | CASA, SOC 2, or equivalent |
-| Can I revoke access? | Should be instant from your admin console |
-| Who processes my data? | No third parties between you and the AI |
+| Are retrieval and write operations separately named and annotated? | Prevents a blanket label from hiding mutation capability |
+| What data is retained, indexed, or logged? | Distinguishes request payloads from operational records |
+| How is authentication handled for each provider? | OAuth, restricted credentials, and roles have different contracts |
+| What has been independently assessed? | Certification scope should match the claim being made |
+| How do disconnect and provider revocation differ? | CorpusIQ and provider-side lifecycles are separate |
+| Which processors receive request context? | The complete flow matters for policy review |
 
 ## The bottom line
 
-Connecting business data to AI doesn't have to be scary. Read-only design, OAuth-native auth, scoped retention, and independent certification make it safer than giving an intern a CSV export.
+Secure connectivity needs operation-level permissions, truthful retention disclosures, provider-specific authorization, and independently assessed controls. Shorter slogans are easier to print. They are also where the trouble starts.
 
 ---
 
-*CorpusIQ: 37+ connectors, read-only by design, CASA Tier 2 certified. [corpusiq.io](https://www.corpusiq.io)*
+*CorpusIQ: 40+ connectors, operation-level permissions, scoped retention, and CASA Tier 2 certification. [corpusiq.io](https://www.corpusiq.io)*

--- a/content/seo/seo-shopify-ai-analytics.md
+++ b/content/seo/seo-shopify-ai-analytics.md
@@ -14,7 +14,7 @@ AI-powered Shopify analytics means asking questions instead:
 
 ## Setup
 
-corpusiq.io → Connect Shopify (read-only OAuth, 30s) → Add MCP to ChatGPT/Claude → Ask.
+corpusiq.io → Connect Shopify (read-only external-source retrieval, 30s) → Add MCP to ChatGPT/Claude → Ask.
 
 Live store data. Every question. No reports.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ CorpusIQ provides read-only external-source retrieval between authorized SaaS ap
 
 - **40+ native connectors**  --  Gmail, Google Drive, Slack, HubSpot, Shopify, QuickBooks, PostgreSQL, and more
 - **MCP-native**  --  Designed for AI assistants that speak the Model Context Protocol
-- **Read-only by design**  --  OAuth scopes are restricted to read access; no write permissions are ever requested
+- **Operation-level permissions**  --  External-source retrieval tools are marked read-only; write-capable and CorpusIQ control-plane tools are separately named and annotated
 - **Scoped data handling**  --  Direct MCP uses live retrieval; optional indexed-search features use embeddings and minimal metadata
 - **SOC 2 aligned & CASA Tier 2 certified**  --  formal SOC 2 certification is not claimed; CASA was assessed by DEKRA
 

--- a/docs/ai-agent-users.md
+++ b/docs/ai-agent-users.md
@@ -146,7 +146,7 @@ A: Any MCP-compatible client. Claude, ChatGPT, Perplexity, local Ollama models, 
 A: No. CorpusIQ is a standalone MCP server. You can use it with a local LLM, any API provider, or any MCP-compatible tool. No vendor lock.
 
 **Q: What data operations can my AI agent perform?**  
-A: Your agent can query ~500 tools across 34 business connectors  --  Stripe revenue, QuickBooks P&L, HubSpot deals, Shopify orders, Meta Ads campaigns, GA4 analytics, PostgreSQL/MSSQL/MongoDB queries  --  all read-only.
+A: Your agent can use the reviewer-visible CorpusIQ tool catalog across business connectors. External-source retrieval tools are marked read-only; write-capable connector-management and CorpusIQ control-plane tools are separately named and annotated.
 
 ---
 

--- a/docs/ai-chat-users.md
+++ b/docs/ai-chat-users.md
@@ -50,7 +50,7 @@ The CorpusIQ AI chat provides natural language access to your connected business
 ## Search and Retrieval Capabilities
 
 - Natural language search across all connected sources
-- Real-time data queries (no cached or stale data)
+- Live source queries; provider and transport caching behavior may vary
 - Cross-source correlation (e.g., Stripe revenue vs Shopify orders)
 - Date range filtering
 - Aggregation and summarization

--- a/docs/ai-for-business-intelligence.md
+++ b/docs/ai-for-business-intelligence.md
@@ -61,7 +61,7 @@ The CorpusIQ MCP platform is purpose-built for AI-powered business intelligence.
 
 2. **MCP-native architecture.** Built on the Model Context Protocol, an open standard for AI-to-tool communication. Any MCP-compatible AI (Claude, ChatGPT, and others) can use CorpusIQ connectors.
 
-3. **Read-only security model.** OAuth 2.0 with read-only scope across all integrations. AI can query data but can never modify systems of record.
+3. **Operation-level security model.** External-source retrieval tools are marked read-only. Write-capable connector-management and CorpusIQ control-plane tools are separately named and safety-annotated.
 
 4. **Cross-source query engine.** Ask one question that spans five tools. "How did our Facebook ad spend correlate with Shopify revenue and Google Analytics traffic last month?"  --  answered in a single response.
 

--- a/docs/ai-for-financial-analysis.md
+++ b/docs/ai-for-financial-analysis.md
@@ -62,7 +62,7 @@ CorpusIQ connects AI to your financial systems through the Model Context Protoco
 - **Stripe integration:** Charges, subscriptions, MRR, refunds, disputes, payouts, balance  --  your payment data becomes conversational.
 - **NetSuite integration:** Enterprise ERP data  --  financials, inventory, orders, procurement  --  accessible through AI.
 - **Cross-source correlation:** Compare QuickBooks to Stripe, NetSuite to Salesforce, Shopify to your accounting system  --  all in one conversation.
-- **Read-only security:** OAuth 2.0 with read-only scope. AI can analyze financial data but can never create, modify, or delete transactions.
+- **Operation-level safety:** Retrieval tools are marked read-only; write-capable connector and control-plane tools are separately named and annotated.
 
 ## Example Financial Analysis Queries
 

--- a/docs/ai-for-project-management.md
+++ b/docs/ai-for-project-management.md
@@ -111,7 +111,7 @@ Status meetings can be shorter and more productive when AI has already gathered 
 A: Monday.com is supported natively. Jira, Asana, and Linear can be accessed via database connectors or API. Direct connectors for additional PM tools are in development.
 
 **Q: Can AI create or update tasks?**
-A: No. All integrations are read-only. AI analyzes and reports on project data but cannot modify it.
+A: The project-management retrieval tools documented here analyze and report on project data; they do not create or update source tasks. Separately named CorpusIQ control-plane tools can update user-declared CorpusIQ state.
 
 **Q: How does AI handle complex project dependencies?**
 A: Claude can analyze task relationships and dependencies when they're represented in your project management tool's data model and identify at-risk dependency chains.

--- a/docs/ai-for-revenue-operations.md
+++ b/docs/ai-for-revenue-operations.md
@@ -64,7 +64,7 @@ The CorpusIQ platform provides the connective tissue that makes unified RevOps p
 - **Billing connectors:** Stripe, QuickBooks, NetSuite.
 - **Analytics connectors:** GA4, PostHog, database connectors (PostgreSQL, MSSQL, MongoDB).
 - **Unified querying:** Ask one question that spans five tools.
-- **Read-only across all systems:** Zero risk of modifying production data.
+- **Explicit tool boundaries:** Retrieval tools are marked read-only; write-capable management/control-plane tools are separately named and annotated.
 
 ## Example RevOps Queries
 

--- a/docs/ai-for-sales-reporting.md
+++ b/docs/ai-for-sales-reporting.md
@@ -62,7 +62,7 @@ CorpusIQ connects AI to your CRM and related systems:
 - **HubSpot integration:** Contacts, companies, deals, pipeline stages, and activity history.
 - **Close CRM integration:** Leads, opportunities, activities, and sales rep performance.
 - **Cross-source correlation:** CRM + ERP + billing + marketing  --  unified revenue intelligence.
-- **Read-only security:** OAuth 2.0 with read-only scope. AI can analyze CRM data but can never modify records.
+- **Operation-level safety:** Retrieval tools are marked read-only; write-capable connector and control-plane tools are separately named and annotated.
 
 ## Example Sales Reporting Queries
 
@@ -120,7 +120,7 @@ A: Yes. CorpusIQ queries the standard REST API, so custom objects and fields acc
 A: Real-time. Every query triggers a live API call to your CRM.
 
 **Q: Can AI create opportunities or update CRM records?**
-A: No. All integrations are read-only.
+A: The CRM retrieval tools documented here do not create opportunities or update source CRM records. Separately named CorpusIQ control-plane tools can update user-declared CorpusIQ state.
 
 ## Internal Links
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -66,7 +66,7 @@ Your backend forwards authenticated user requests to CorpusIQ. The API token nev
 
 ### Token Revocation
 
-Tokens can be revoked from the Dashboard (**Settings → API → Revoke All Tokens**). The service commits an inactive state before credential cleanup and surfaces cleanup failures for retry. If a token is compromised, revoke it through CorpusIQ and the provider, then generate a new one.
+The Dashboard can clear CorpusIQ MCP session state so a fresh token is required at the next login. This does not revoke authorization held by a connected provider; manage provider-side authorization in the provider's controls.
 
 ## Header Reference
 
@@ -74,7 +74,6 @@ Tokens can be revoked from the Dashboard (**Settings → API → Revoke All Toke
 |--------|----------|-------------|
 | `Authorization` | Yes | `Bearer <token>` |
 | `Content-Type` | Yes (POST) | Must be `application/json` |
-| `Idempotency-Key` | Optional | Unique key for idempotent `/query` requests |
 
 ## Testing Authentication
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -23,7 +23,6 @@ Search across all connected data sources with a natural-language query.
 POST /v1/query
 Content-Type: application/json
 Authorization: Bearer <token>
-Idempotency-Key: <unique-key>  (optional)
 ```
 
 | Field | Type | Required | Description |
@@ -74,14 +73,6 @@ Idempotency-Key: <unique-key>  (optional)
 }
 ```
 
-### Idempotency
-
-Pass an `Idempotency-Key` header to safely retry `/query` requests without creating duplicate query records. The key must be unique per request. Subsequent requests with the same key within 24 hours return the cached response.
-
-```http
-Idempotency-Key: req_2026-06-16_sales_report
-```
-
 ### Code Examples
 
 **cURL**
@@ -90,7 +81,6 @@ Idempotency-Key: req_2026-06-16_sales_report
 curl -X POST https://mcp2.corpusiq.io/mcp \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
-  -H "Idempotency-Key: $(uuidgen)" \
   -d '{
     "query": "Show me recent HubSpot deals over $10,000",
     "connectors": ["hubspot"],
@@ -106,7 +96,6 @@ const response = await fetch("https://mcp2.corpusiq.io/mcp", {
   headers: {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
-    "Idempotency-Key": crypto.randomUUID(),
   },
   body: JSON.stringify({
     query: "Show me recent HubSpot deals over $10,000",
@@ -123,14 +112,12 @@ console.log(data.results);
 
 ```python
 import requests
-import uuid
 
 response = requests.post(
     "https://mcp2.corpusiq.io/mcp",
     headers={
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
-        "Idempotency-Key": str(uuid.uuid4()),
     },
     json={
         "query": "Show me recent HubSpot deals over $10,000",

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -30,7 +30,7 @@ All CorpusIQ API errors follow a consistent JSON structure with a machine-readab
 | **401** | `unauthorized` | The Bearer token is missing, invalid, or expired. Obtain a new token. An `X-Token-Expired: true` header accompanies expired tokens. |
 | **403** | `forbidden` | The authenticated user does not have permission to access the requested resource or connector. Verify connector OAuth scopes. |
 | **404** | `not_found` | The requested resource (query ID, connector, or endpoint) does not exist. Check the URL and resource identifiers. |
-| **409** | `conflict` | The request conflicts with the current state. Common for duplicate `Idempotency-Key` submissions with different request bodies. |
+| **409** | `conflict` | The request conflicts with the current resource state. Inspect the response details before retrying. |
 | **413** | `payload_too_large` | The request body exceeds the maximum allowed size of 1 MB. Reduce `max_results` or split the query. |
 | **429** | `rate_limited` | The rate limit for the endpoint has been exceeded. A `retry_after_seconds` field indicates when to retry. See [Rate Limits](/docs/api/rate-limits). |
 | **500** | `server_error` | An unexpected internal error occurred on the CorpusIQ side. Retry with exponential backoff. If errors persist, contact api@corpusiq.io. |
@@ -85,9 +85,9 @@ for attempt in range(max_retries):
         time.sleep(wait)
 ```
 
-## Idempotency and 409 Conflicts
+## 409 Conflicts
 
-A `409 Conflict` with `Idempotency-Key` means the same key was used with a different request body. Generate a new key for each unique request. If the request body is identical, the API returns the cached response with a `200` status.
+A `409 Conflict` means the request conflicts with current resource state. Inspect the response details and do not assume a retry is safe.
 
 ## Frequently Asked Questions
 

--- a/docs/api/openapi.md
+++ b/docs/api/openapi.md
@@ -58,14 +58,6 @@ paths:
         Execute a natural-language query across all or specified connected business
         tools. Returns semantically ranked, cited results from each connector.
       operationId: "searchQuery"
-      parameters:
-        - name: "Idempotency-Key"
-          in: "header"
-          required: false
-          schema:
-            type: "string"
-            format: "uuid"
-          description: "Unique key for idempotent requests. Prevents duplicate query records."
       requestBody:
         required: true
         content:

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -30,7 +30,7 @@ All endpoint paths are relative to this base. The API version (`v1`) is part of 
 
 The primary endpoint for querying connected business tools. Accepts a natural-language question and an optional list of connector IDs to scope the search. CorpusIQ translates the query into read-only API calls, retrieves matching records, ranks them semantically, and returns cited results.
 
-Each `/query` request generates a unique `query_id` that can be used for idempotency and debugging. The `Idempotency-Key` header protects against duplicate submissions.
+Each `/query` request generates a unique `query_id` for tracing and debugging.
 
 ### POST /deep_search
 
@@ -72,7 +72,7 @@ A: The API offers POST /query for connected-source search and POST /deep_search 
 A: All successful responses return HTTP 200 with a JSON body. Errors follow a consistent format with 'type' and 'message' fields. See the errors reference for complete error codes.
 
 **Q: Is the CorpusIQ API read-only?**  
-A: Yes. All API endpoints are read-only. The platform never writes, modifies, or deletes your business data. This is enforced at the protocol, connector, and OAuth scope levels.
+A: External-source retrieval endpoints are read-only. Connector-management and CorpusIQ control-plane endpoints can change CorpusIQ-owned state and are documented separately.
 
 **Q: How fast are API query responses?**  
 A: Most queries return results in 1–5 seconds. Cross-source queries spanning multiple business tools may take slightly longer depending on the number of API calls required.

--- a/docs/api/rate-limits.md
+++ b/docs/api/rate-limits.md
@@ -74,9 +74,9 @@ if remaining < 5:
     time.sleep(10)  # Let the rate limit window catch up
 ```
 
-### Use Idempotency Keys
+### Retry Explicitly
 
-For `/query`, use `Idempotency-Key` headers to safely retry without consuming additional rate limit quota. Duplicate requests with the same key within 24 hours return a cached response and do not count against your limit.
+Retry only after an explicit transient error, and follow the response status and retry guidance.
 
 ### Batch Questions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -60,7 +60,7 @@ Individual adapters for each of the 36 supported business data sources. Each con
 
 ## Security Model
 
-- Read-only access to all connected data sources
+- Read-only external-source retrieval with separately annotated management/control-plane writes
 - OAuth 2.0 with refresh token rotation
 - Device flow prevents credential exposure
 - HTTPS/TLS for all connections

--- a/docs/benefits-of-mcp-for-business.md
+++ b/docs/benefits-of-mcp-for-business.md
@@ -20,15 +20,15 @@ This real-time capability eliminates the decision latency that plagues tradition
 
 Consider a retail business monitoring Black Friday performance. With a data warehouse, they're looking at data that's hours old. With MCP, they can ask "what's selling fastest right now?" and get an answer drawn from live Shopify data. That timeliness translates to better decisions about inventory reallocation, promotional adjustments, and staffing.
 
-## 2. Security by Design: Read-Only Access
+## 2. Security by Design: Explicit Tool Boundaries
 
-MCP servers, as implemented by CorpusIQ, default to read-only access. This is not an accident  --  it's a deliberate architectural choice that eliminates the largest category of integration risk: unintended data modification.
+CorpusIQ separates external-source retrieval from write-capable connector-management and CorpusIQ control-plane operations. Tool names, schemas, and safety annotations make that boundary visible before invocation.
 
 Every other integration approach  --  direct API access, RPA bots, database connections  --  requires careful permission management to prevent write operations. A developer with a database connection string can potentially modify or delete records. An RPA bot with user credentials can perform any action the user can. Even a well-intentioned API integration can have bugs that modify production data.
 
-MCP's read-only default means even a misconfigured query or an erroneous AI suggestion cannot modify your data. The worst that can happen is an incorrect answer  --  not an incorrect database update. This property is particularly valuable for financial systems, CRM platforms, and other mission-critical data sources where data integrity is paramount.
+Retrieval tools marked read-only cannot execute write operations. Write-capable tools are separately named and limited to their declared actions. This reduces unintended-change risk for financial systems, CRM platforms, and other mission-critical sources without claiming that the whole product is read-only.
 
-For organizations that do need write capabilities, CorpusIQ supports scoped write operations with explicit opt-in at both the OAuth and server configuration levels. But the default is safety.
+AI clients can use the published safety annotations when deciding whether to request confirmation. The exact confirmation behavior remains governed by the selected client's interface and policy.
 
 ## 3. AI-Native Simplicity
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,7 +33,7 @@ The first public release of the CorpusIQ API, providing programmatic access to t
 
 ### New Endpoints
 
-- **`POST /v1/query`**  --  Search across all connected business tools with natural-language queries. Supports connector scoping via the `connectors` parameter and idempotent submissions via the `Idempotency-Key` header. Returns semantically ranked, cited results from each matching connector.
+- **`POST /v1/query`**  --  Search across all connected business tools with natural-language queries. Supports connector scoping via the `connectors` parameter and returns semantically ranked, cited results from each matching connector.
 
 - **`POST /v1/deep_search`**  --  Search the encrypted archive of previously executed queries and their results. Supports date-range filtering and returns similarity-scored matches.
 
@@ -43,7 +43,7 @@ The first public release of the CorpusIQ API, providing programmatic access to t
 - Bearer token authentication via `Authorization` header
 - 60-minute token expiry with server-side refresh detection
 - Token issuance through the CorpusIQ Dashboard and ChatGPT Actions
-- Immediate token revocation from the Dashboard
+- Dashboard disconnect commits inactive CorpusIQ connection state; provider-side authorization remains governed by the provider
 
 ### OpenAPI Specification
 
@@ -60,7 +60,7 @@ The first public release of the CorpusIQ API, providing programmatic access to t
 
 ### Security
 
-- Read-only OAuth scopes across all connectors
+- Operation-level safety annotations distinguish external-source retrieval from write-capable management/control-plane tools
 - Scoped data handling: direct MCP live retrieval plus optional indexed-search embeddings
 - TLS 1.3 for all API traffic
 - AES-256-GCM encryption at rest
@@ -69,7 +69,7 @@ The first public release of the CorpusIQ API, providing programmatic access to t
 ### Connectors
 
 - 40+ native connectors spanning email, calendar, file storage, analytics, CRM, ecommerce, marketing, financial, social media, and databases
-- Read-only OAuth for all cloud services
+- Provider scopes match each connector's documented operations
 - Direct database connectors for PostgreSQL, SQL Server, MySQL, Azure Cosmos DB, and MongoDB
 
 ### Documentation

--- a/docs/chatgpt-for-quickbooks.md
+++ b/docs/chatgpt-for-quickbooks.md
@@ -32,7 +32,7 @@ Instead of navigating QuickBooks' report menus or exporting CSV files for analys
 
 CorpusIQ's MCP platform acts as the secure middleware layer between ChatGPT and QuickBooks Online. Here's the workflow:
 
-1. **Connect Your QuickBooks Account**  --  Authenticate via OAuth 2.0 in under 60 seconds. CorpusIQ establishes a read-only connection to your QuickBooks company file, ensuring your financial data can be queried but never modified by the AI.
+1. **Connect Your QuickBooks Account**  --  Authenticate via OAuth 2.0 in under 60 seconds. CorpusIQ exposes separately named QuickBooks retrieval tools that are marked read-only; write-capable tools, when present, are separately annotated.
 
 2. **ChatGPT Gains Financial Context**  --  Once connected, CorpusIQ exposes QuickBooks as a set of structured tools that ChatGPT can invoke. These include profit & loss reports, balance sheets, accounts receivable aging, invoice lookups, customer searches, and vendor lists.
 

--- a/docs/chatgpt-for-shopify.md
+++ b/docs/chatgpt-for-shopify.md
@@ -84,7 +84,7 @@ A product manager asks: "Show me the first 30 days of sales for our three most r
 Yes. CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 
 ### Can ChatGPT modify my Shopify store?
-No. The CorpusIQ-Shopify connection is strictly read-only. ChatGPT can analyze your data and make recommendations, but it cannot create products, modify orders, change inventory, adjust prices, or alter any store settings. Your store remains fully under your control.
+The advertised Shopify retrieval tools are read-only and support analysis and recommendations without changing store records. Write-capable tools, when available, are separately named and annotated.
 
 ### What Shopify data can ChatGPT access?
 ChatGPT can access orders, products, customers, inventory levels, discount codes, refund data, and store analytics. It can query across all these data types and perform calculations  --  revenue analysis, customer segmentation, product performance, inventory forecasting  --  using your live data.

--- a/docs/chatgpt-integration.md
+++ b/docs/chatgpt-integration.md
@@ -64,7 +64,7 @@ All 36 CorpusIQ connectors are available through the ChatGPT integration. See th
 ## Frequently Asked Questions
 
 **Q: How do I connect CorpusIQ to ChatGPT?**  
-A: Open ChatGPT, search for 'CorpusIQ', click Connect to authorize via OAuth, and link your CorpusIQ account. ChatGPT will have immediate read-only access to all your connected business data sources.
+A: Open ChatGPT, search for 'CorpusIQ', click Connect, and authorize your CorpusIQ account. External-source retrieval tools are marked read-only; write-capable and CorpusIQ control-plane tools are separately named and annotated.
 
 **Q: What can I ask ChatGPT with CorpusIQ connected?**  
 A: Ask about MRR, revenue trends, top customers, marketing ROAS, order volumes, P&L statements, pipeline value, and more. Example: 'What was our MRR last month?' or 'Compare this month's revenue to last month.'

--- a/docs/claude-for-quickbooks.md
+++ b/docs/claude-for-quickbooks.md
@@ -88,7 +88,7 @@ The context window is how much information the AI can "hold in mind" at once. Cl
 CorpusIQ uses a read-only QuickBooks connection and encrypted transport. Data handling inside Claude follows the terms and settings of the Anthropic plan you choose; review Anthropic's current policy before sending sensitive financial data.
 
 ### Can Claude create QuickBooks journal entries?
-No. Like all CorpusIQ AI integrations, the QuickBooks connection is read-only. Claude can identify needed adjustments and draft journal entry recommendations, but a human must approve and enter them into QuickBooks. This separation of analysis from execution is a deliberate safety feature.
+The QuickBooks retrieval tools documented here are read-only and can identify adjustments or draft recommendations. Write-capable connector and CorpusIQ control-plane tools, when present, are separately named and annotated.
 
 ### Does Claude work with QuickBooks Desktop?
 Claude through CorpusIQ connects to QuickBooks Online via the QuickBooks API. QuickBooks Desktop is not directly supported, though enterprise customers can arrange for batch data imports. Contact our sales team for Desktop integration options.

--- a/docs/connect-asana-to-chatgpt.md
+++ b/docs/connect-asana-to-chatgpt.md
@@ -33,7 +33,7 @@ CorpusIQ connects to your Asana account via OAuth 2.0. You authorize read-only a
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only OAuth scopes from Asana. ChatGPT can see projects, tasks, sections, assignees, and custom fields. It cannot create tasks, reassign work, change due dates, modify projects, or alter anything in your Asana workspace. The read-only guarantee is enforced at both the OAuth permission and MCP tool layers.
+Yes. CorpusIQ requests read-only external-source retrieval scopes from Asana. ChatGPT can see projects, tasks, sections, assignees, and custom fields. It cannot create tasks, reassign work, change due dates, modify projects, or alter anything in your Asana workspace. The read-only guarantee is enforced at both the OAuth permission and MCP tool layers.
 </details>
 
 <details>

--- a/docs/connect-gmail-to-chatgpt.md
+++ b/docs/connect-gmail-to-chatgpt.md
@@ -33,7 +33,7 @@ CorpusIQ connects to your Gmail account via Google OAuth 2.0 with read-only scop
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only Gmail scopes: gmail.readonly. ChatGPT can search, list, and read emails. It cannot send emails, delete messages, modify labels, change settings, or perform any write operation in your Gmail account. The read-only guarantee is enforced by the Google OAuth scope  --  Gmail's readonly scope does not include any write capabilities.
+Yes. CorpusIQ requests read-only Gmail scopes: gmail.readonly. ChatGPT can search, list, and read emails. It cannot send emails, delete messages, modify labels, change settings, or perform any write operation in your Gmail account. The advertised Gmail retrieval tools are marked read-only. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>

--- a/docs/connect-hubspot-to-chatgpt.md
+++ b/docs/connect-hubspot-to-chatgpt.md
@@ -33,7 +33,7 @@ CorpusIQ connects to HubSpot via OAuth 2.0 and exposes HubSpot's CRM objects as 
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only scopes from HubSpot. ChatGPT can see contacts, deals, and companies. It cannot create contacts, move deals between stages, modify company properties, or change anything in your CRM. The read-only guarantee is enforced at both the OAuth scope level and the MCP tool level.
+The advertised HubSpot retrieval tools are read-only and expose contacts, deals, and companies without modifying them. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>
@@ -126,10 +126,10 @@ Instead of building a pipeline report in HubSpot: "Show me all deals by stage wi
 
 ## Security: Read-Only by Design
 
-The HubSpot integration is read-only at every layer:
+The advertised HubSpot retrieval surface is read-only:
 
-- **OAuth Scopes:** Read-only access to contacts, companies, deals, and account metadata. No write, create, update, or delete permissions.
-- **MCP Tools:** Only query tools are exposed  --  contact search, deal listing, company retrieval. No tools exist to create, modify, or delete HubSpot records.
+- **Retrieval tools:** Contact search, deal listing, and company retrieval are marked read-only.
+- **Other operations:** Write-capable tools, when available, are separately named and annotated.
 - **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 - **Encryption:** All data in transit is encrypted via TLS 1.3 between HubSpot, CorpusIQ, and ChatGPT.
 

--- a/docs/connect-hubspot-to-claude.md
+++ b/docs/connect-hubspot-to-claude.md
@@ -71,9 +71,9 @@ CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain
 
 ### Security
 
-- **Read-only OAuth 2.0.** Claude can query contacts, companies, and deals but cannot create, update, or delete CRM records.
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
-- **Instant disconnect.** Revoke access from HubSpot or CorpusIQ at any time.
+- **Operation-level safety.** HubSpot retrieval tools are marked read-only; write-capable tools, when present, are separately named and annotated.
+- **Scoped direct-MCP retention.** Direct MCP does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Disconnect behavior.** CorpusIQ disconnect requires reauthorization before reuse; provider authorization remains governed by HubSpot.
 
 ### Comparison: MCP vs. HubSpot API Direct
 

--- a/docs/connect-monday-com-to-chatgpt.md
+++ b/docs/connect-monday-com-to-chatgpt.md
@@ -33,7 +33,7 @@ CorpusIQ connects to your Monday.com account via OAuth 2.0. You authorize read-o
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only OAuth scopes from Monday.com. ChatGPT can see boards, items, statuses, owners, and due dates. It cannot create items, update statuses, reassign tasks, or modify anything in your Monday.com account. The read-only guarantee is enforced at the OAuth scope level.
+Yes. CorpusIQ requests read-only external-source retrieval scopes from Monday.com. ChatGPT can see boards, items, statuses, owners, and due dates. It cannot create items, update statuses, reassign tasks, or modify anything in your Monday.com account. The advertised Monday.com retrieval tools are marked read-only; write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>

--- a/docs/connect-notion-to-chatgpt.md
+++ b/docs/connect-notion-to-chatgpt.md
@@ -132,11 +132,11 @@ The Notion integration provides layered security:
 
 - **Integration Token** with read-only capabilities. No content creation, editing, or deletion.
 - **Page-Level Sharing.** You explicitly share each top-level page and database with the integration. Unshared pages are inaccessible regardless of workspace membership.
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Scoped direct-MCP retention.** Notion retrieval tools are marked read-only. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 - **TLS 1.3 Encryption.** All data in transit is encrypted.
-- **Token Revocation.** Revoke the integration token from Notion at any time to immediately cut off access.
+- **Provider authorization.** Manage the integration token through Notion; provider-side timing remains governed by Notion.
 
-For organizations with sensitive documentation  --  IP, strategy, customer data  --  this architecture provides granular access control: expose only the pages you want ChatGPT to access, and revoke access instantly if needed.
+For organizations with sensitive documentation  --  IP, strategy, customer data  --  this architecture provides granular access control: expose only the pages you want ChatGPT to access, and manage provider authorization in Notion when needed.
 
 ## Comparison: MCP vs. Notion Built-in Search
 

--- a/docs/connect-quickbooks-to-chatgpt.md
+++ b/docs/connect-quickbooks-to-chatgpt.md
@@ -33,7 +33,7 @@ CorpusIQ connects to your QuickBooks Online company file via OAuth 2.0. You auth
 <details>
 <summary><strong>Is this read-only? Can ChatGPT modify my books?</strong></summary>
 
-Yes, entirely read-only. CorpusIQ requests read-only OAuth scopes from Intuit. ChatGPT can view your P&L, balance sheet, invoices, payments, customers, vendors, and chart of accounts. It cannot create invoices, record payments, modify journal entries, or alter anything in your QuickBooks file. The read-only guarantee is enforced at the OAuth permission layer and at the MCP server tool level.
+The QuickBooks retrieval tools documented here are marked read-only and cover reports, invoices, payments, customers, vendors, and accounts. Provider scopes are those required by Intuit for the documented operations; write-capable tools, when present, are separately named and annotated.
 </details>
 
 <details>
@@ -88,7 +88,7 @@ CorpusIQ uses your QuickBooks default reporting basis. If your company is set to
 
 The architecture is clean and secure:
 
-1. **Connect QuickBooks to CorpusIQ.** Click Connections → QuickBooks in your CorpusIQ dashboard. Sign into Intuit, select your company file, and approve read-only access. Takes 2 minutes.
+1. **Connect QuickBooks to CorpusIQ.** Click Connections → QuickBooks in your CorpusIQ dashboard. Sign into Intuit, select your company file, and review and approve the provider scopes. Takes 2 minutes.
 
 2. **Connect CorpusIQ to ChatGPT.** Add the CorpusIQ MCP server as a connected app in ChatGPT. The server advertises its available financial tools to ChatGPT automatically.
 
@@ -134,11 +134,11 @@ Start every morning by asking ChatGPT: "What's our cash position today?" "Any pa
 
 ## Security: Read-Only by Design
 
-CorpusIQ's QuickBooks integration is read-only at every layer:
+CorpusIQ publishes operation-level permissions for QuickBooks:
 
-- **OAuth Scopes:** Only read permissions are requested from Intuit  --  no write, modify, or delete scopes.
-- **MCP Tools:** The QuickBooks connector tools are query-only  --  P&L report, invoice list, balance sheet, AR aging, customer list. There is no tool to create, update, or delete anything.
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Provider scopes:** CorpusIQ requests the Intuit scopes required for documented operations.
+- **MCP tools:** Retrieval and write-capable operations are separately named and safety-annotated.
+- **Scoped direct-MCP retention.** QuickBooks retrieval tools are marked read-only. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 - **Encrypted in Transit:** All data between QuickBooks, CorpusIQ, and ChatGPT is encrypted via TLS 1.3.
 
 For organizations in regulated industries, this read-only architecture eliminates the most common financial data risk: unintended modification. Even a misdirected query cannot change your books.

--- a/docs/connect-quickbooks-to-claude.md
+++ b/docs/connect-quickbooks-to-claude.md
@@ -25,7 +25,7 @@ QuickBooks contains your company's financial truth  --  profit and loss, balance
 - **AR/AP visibility.** Ask "Which customers owe us more than $5,000?" or "What bills are due next week?" without digging through QuickBooks screens.
 - **Cross-source financial intelligence.** Combine QuickBooks data with Shopify revenue, Stripe payments, or Salesforce pipeline for a complete financial picture.
 - **Cash flow at your fingertips.** Claude can analyze your balance sheet, AR aging, and AP aging together to give you an instant cash position assessment.
-- **Read-only security.** OAuth 2.0 with read-only scope. Claude can analyze your financial data but can never create, modify, or delete transactions.
+- **Operation-level safety.** QuickBooks retrieval tools are marked read-only; write-capable tools, when present, are separately named and annotated.
 
 ### How It Works
 
@@ -36,7 +36,7 @@ The CorpusIQ MCP architecture for QuickBooks follows the same secure pattern as 
 3. **CorpusIQ translates** your question into the appropriate QuickBooks API calls and executes them with your stored credentials.
 4. **Claude presents** the results in natural language, with calculated metrics, trend observations, and actionable context.
 
-The connection is always live  --  every question triggers a fresh API call, so you're never looking at stale financial data.
+Each question requests current QuickBooks data. Freshness follows QuickBooks and CorpusIQ cache behavior; verify time-sensitive values against cited records.
 
 ### Setup Steps
 
@@ -85,8 +85,8 @@ Financial data is among the most sensitive information in any organization. Corp
 
 - **Read-only OAuth 2.0.** Claude can query financial data but can never create journal entries, modify invoices, or delete transactions.
 - **Documented controls.** CorpusIQ maintains a SOC 2 aligned posture and is CASA Tier 2 certified by DEKRA; formal SOC 2 certification is not claimed.
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
-- **Instant revocability.** Disconnect QuickBooks from CorpusIQ or revoke the Intuit token at any time.
+- **Scoped direct-MCP retention.** QuickBooks retrieval tools are marked read-only. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Disconnect behavior.** CorpusIQ disconnect commits inactive connection state and requires reauthorization; provider authorization remains governed by Intuit.
 - **Audit trail.** All queries through CorpusIQ are logged, giving your compliance team visibility into who asked what and when.
 
 ### Comparison: MCP vs. Direct QuickBooks API
@@ -133,7 +133,7 @@ The integration supports QuickBooks Online. QuickBooks Desktop is not currently 
 <details>
 <summary><strong>Can Claude create invoices or journal entries?</strong></summary>
 
-No. The integration is strictly read-only. Claude can analyze and report on financial data but cannot create, modify, or delete anything in QuickBooks.
+The advertised QuickBooks retrieval tools are read-only and do not create, modify, or delete records. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>

--- a/docs/connect-salesforce-to-claude.md
+++ b/docs/connect-salesforce-to-claude.md
@@ -25,7 +25,7 @@ Salesforce is powerful but complex. The average enterprise Salesforce org has hu
 - **Cross-source enterprise intelligence.** Combine Salesforce pipeline with NetSuite financials, Stripe billing, or Snowflake analytics.
 - **Meeting intelligence.** Before any customer call, ask Claude for the account's full history  --  opportunities, cases, recent activity.
 - **Forecasting support.** Claude can analyze pipeline velocity, historical close rates, and current opportunities to support forecast discussions.
-- **Read-only security.** OAuth 2.0 with read-only scope. Claude can never modify your Salesforce data.
+- **Operation-level safety.** Retrieval tools are marked read-only; write-capable tools, when present, are separately named and annotated.
 
 ### How It Works
 
@@ -95,7 +95,7 @@ CorpusIQ queries standard Salesforce REST API endpoints. Custom objects accessib
 <details>
 <summary><strong>Can Claude modify Salesforce records?</strong></summary>
 
-No. The integration is strictly read-only.
+The advertised Salesforce retrieval tools are read-only. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>

--- a/docs/connect-shopify-to-chatgpt.md
+++ b/docs/connect-shopify-to-chatgpt.md
@@ -33,7 +33,7 @@ CorpusIQ uses the Model Context Protocol (MCP)  --  an open standard for connect
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only OAuth scopes from Shopify. ChatGPT can see orders, products, customers, and store analytics. It cannot create orders, modify products, issue refunds, change prices, or alter anything in your store. The worst that can happen is an incorrect answer  --  never an incorrect database update.
+Yes. CorpusIQ requests read-only external-source retrieval scopes from Shopify. ChatGPT can see orders, products, customers, and store analytics. It cannot create orders, modify products, issue refunds, change prices, or alter anything in your store. The worst that can happen is an incorrect answer  --  never an incorrect database update.
 </details>
 
 <details>
@@ -82,7 +82,7 @@ CorpusIQ offers a free 30-day trial that includes the Shopify connector. After t
 
 The architecture is straightforward. CorpusIQ acts as a secure MCP bridge between ChatGPT and your Shopify store. Here's the flow:
 
-1. **Connect Shopify to CorpusIQ.** You authorize CorpusIQ to access your Shopify store via read-only OAuth. This takes about 2 minutes  --  enter your store's myshopify.com domain, sign into Shopify, and approve the requested scopes.
+1. **Connect Shopify to CorpusIQ.** You authorize CorpusIQ to access your Shopify store via read-only external-source retrieval. This takes about 2 minutes  --  enter your store's myshopify.com domain, sign into Shopify, and approve the requested scopes.
 
 2. **Connect CorpusIQ to ChatGPT.** In ChatGPT, you add the CorpusIQ MCP server as a connected app. ChatGPT discovers all your connected data sources automatically. See our [ChatGPT integration guide](chatgpt-integration.md) for step-by-step instructions.
 

--- a/docs/connect-shopify-to-claude.md
+++ b/docs/connect-shopify-to-claude.md
@@ -78,7 +78,7 @@ Once connected, Claude can answer an enormous range of Shopify questions. Here a
 
 ### Security and Permissions
 
-CorpusIQ uses OAuth 2.0 with read-only scope for the Shopify integration. This means:
+Shopify provider scopes vary by documented operation. The retrieval tools described here are marked read-only:
 
 - **Claude can read** your orders, products, customers, and analytics.
 - **Claude can never write**  --  it cannot create, update, or delete anything in your Shopify store.
@@ -118,13 +118,13 @@ No. The OAuth flow is point-and-click. Anyone with Shopify admin access can conn
 <details>
 <summary><strong>Can Claude modify my Shopify store  --  create products, update orders, or change prices?</strong></summary>
 
-No. The integration is strictly read-only. Claude can query your data but cannot make any changes to your Shopify store.
+The advertised Shopify retrieval tools are read-only and do not change the store. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>
 <summary><strong>How current is the data Claude sees?</strong></summary>
 
-Real-time. Every question you ask triggers a fresh API call to Shopify. Claude always works with live data, not cached snapshots.
+Each question requests current Shopify data. Freshness follows Shopify and CorpusIQ cache behavior; use cited source records for time-sensitive verification.
 </details>
 
 <details>
@@ -136,7 +136,7 @@ The integration works with any Shopify plan that includes API access. Most plans
 <details>
 <summary><strong>Can I limit which data Claude can access?</strong></summary>
 
-Yes. The OAuth scope is read-only across orders, products, customers, and analytics. You can further restrict access by only granting specific scopes during authorization.
+Yes. The advertised Shopify retrieval tools for orders, products, customers, and analytics are marked read-only; write-capable tools, when available, are separately named and annotated. You can further restrict access by only granting specific scopes during authorization.
 </details>
 
 <details>

--- a/docs/connect-slack-to-chatgpt.md
+++ b/docs/connect-slack-to-chatgpt.md
@@ -33,7 +33,7 @@ CorpusIQ connects to your Slack workspace via OAuth 2.0. You authorize read-only
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only OAuth scopes from Slack. ChatGPT can read channels, search messages, retrieve threads, and access workspace analytics. It cannot send messages, create channels, modify workspace settings, or perform any write operation. The read-only guarantee is enforced by the Slack OAuth scopes requested during authorization.
+Yes. CorpusIQ requests read-only external-source retrieval scopes from Slack. ChatGPT can read channels, search messages, retrieve threads, and access workspace analytics. It cannot send messages, create channels, modify workspace settings, or perform any write operation. The advertised Slack retrieval tools are marked read-only; write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>

--- a/docs/connect-slack-to-claude.md
+++ b/docs/connect-slack-to-claude.md
@@ -112,7 +112,7 @@ Claude can search across public channels and private channels it has been added 
 A: Claude can only access public channels and private channels it has been explicitly added to. Direct messages are never accessible.
 
 **Q: Can Claude send messages to Slack?**
-A: No. The integration is strictly read-only.
+A: The advertised Slack retrieval tools are read-only and do not send messages. Write-capable tools, when available, are separately named and annotated.
 
 **Q: How far back can Claude search?**
 A: Claude can search your entire message history, subject to your Slack workspace's retention settings.

--- a/docs/connect-stripe-to-claude.md
+++ b/docs/connect-stripe-to-claude.md
@@ -96,7 +96,7 @@ CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain
 <details>
 <summary><strong>Can Claude create charges or modify subscriptions?</strong></summary>
 
-No. The integration is strictly read-only. Use a restricted API key with only read permissions.
+The advertised Stripe retrieval tools use restricted read access and do not create charges or modify subscriptions. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -12,7 +12,7 @@ robots: "index,follow"
 Connect QuickBooks, Shopify, Stripe, HubSpot, GA4, and 35+ more business tools to ChatGPT, Claude, and Perplexity through read-only direct MCP live retrieval. CorpusIQ does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days. Browse the complete directory below.
 # Connectors
 
-CorpusIQ integrates with 40+ business tools through read-only OAuth connections. Each connector maps to a specific SaaS application or database, enabling natural-language queries across your entire data stack.
+CorpusIQ integrates with 40+ business tools through source-specific authorization. Each connector maps to a SaaS application or database, and each published operation declares whether it is read-only or write-capable.
 
 For the full interactive connector list with real-time status indicators, visit [corpusiq.io/connectors](https://corpusiq.io/connectors).
 
@@ -117,14 +117,14 @@ For the full interactive connector list with real-time status indicators, visit 
 
 ## Connecting a New Service
 
-All connectors use read-only OAuth scopes. To connect a new service:
+Each connector requests the provider scopes needed for its documented operations. To connect a new service:
 
 1. Log in to the [CorpusIQ Dashboard](https://corpusiq.io/dashboard)
 2. Navigate to **Connections**
 3. Click the service you want to connect
 4. Complete the OAuth authorization flow
 
-CorpusIQ never requests write permissions. You can verify the exact OAuth scopes requested on the authorization screen.
+You can verify the exact provider scopes requested on the authorization screen and inspect each MCP tool's safety annotations.
 
 ## Connector Status
 
@@ -135,13 +135,13 @@ For the latest connector count and status, visit [corpusiq.io/connectors](https:
 ## Frequently Asked Questions
 
 **Q: How many connectors does CorpusIQ support?**  
-A: CorpusIQ supports 40+ native connectors spanning CRM, accounting, payments, analytics, marketing, ecommerce, file storage, communication, databases, and more. All connectors are read-only via OAuth.
+A: CorpusIQ supports 40+ native connectors spanning CRM, accounting, payments, analytics, marketing, ecommerce, file storage, communication, databases, and more. External-source retrieval and write-capable management/control-plane operations are separately named and annotated.
 
 **Q: How do I connect a new data source?**  
 A: Log into the CorpusIQ Dashboard, navigate to Connections, click the service you want to connect, and complete the OAuth authorization flow. Each connection takes under 60 seconds.
 
 **Q: Are CorpusIQ connectors read-only?**  
-A: Yes. All connectors use read-only OAuth scopes. CorpusIQ never requests write permissions. You can verify the exact scopes on the OAuth authorization screen during connection setup.
+A: External-source retrieval tools are marked read-only. Write-capable connector-management and CorpusIQ control-plane tools are separately named and annotated. Provider scopes vary by connector and are shown during authorization.
 
 **Q: Does CorpusIQ support database connections?**  
 A: Yes. CorpusIQ supports PostgreSQL, MSSQL (SQL Server), MySQL, Azure Cosmos DB, and MongoDB  --  all with read-only SQL/query access.

--- a/docs/corpusiq-vs-fivetran.md
+++ b/docs/corpusiq-vs-fivetran.md
@@ -36,7 +36,7 @@ Fivetran is the leading managed ETL (Extract, Transform, Load) platform, automat
 
 **Fivetran's model:** Extract data from source → transform it → load it into a warehouse → query the warehouse with SQL or BI tools.
 
-**CorpusIQ's model:** AI asks a question → CorpusIQ queries the live source via API → AI presents the answer. No intermediate copy.
+**CorpusIQ's model:** AI asks a question → CorpusIQ queries the live source via API → AI presents the answer. Direct MCP does not retain raw customer files or full connector response payloads; optional indexed search is separate.
 
 This architectural difference has cascading implications for cost, speed, freshness, and complexity.
 
@@ -45,13 +45,13 @@ This architectural difference has cascading implications for cost, speed, freshn
 | Feature | CorpusIQ | Fivetran |
 |---------|----------|----------|
 | **Approach** | Real-time API query (MCP) | Batch ETL pipelines |
-| **Data Freshness** | Instant  --  queries live source | 5 min to 24 hours (sync frequency) |
+| **Data Freshness** | Requested from the provider; freshness follows provider and cache behavior | 5 min to 24 hours (sync frequency) |
 | **Source-data replication** | No raw-file/full-payload warehouse | Full replication to warehouse |
 | **Infrastructure Required** | None | Data warehouse (Snowflake, BigQuery, etc.) |
 | **Setup Complexity** | 2-minute OAuth | Hours to days (connector + warehouse config) |
 | **AI Integration** | Native MCP protocol | Indirect (SQL queries via warehouse) |
 | **Cost Model** | Per-seat subscription | Per-row (MAR) + warehouse costs |
-| **Data Storage** | No replicated source-data warehouse; scoped operational logs up to 30 days | Permanent warehouse copy |
+| **Data Storage** | Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may persist up to 30 days | Permanent warehouse copy |
 | **Schema Management** | Automatic (API-driven) | Manual schema changes, dbt transforms |
 | **Use Case** | AI-powered business questions | Centralized analytics and reporting |
 
@@ -63,7 +63,7 @@ Every source-data copy creates a governance, security, and freshness burden. Cor
 **Why this matters:** GDPR compliance, SOC 2 audits, and internal data governance all become simpler when you don't maintain additional copies of sensitive business data.
 
 ### 2. Real-Time Freshness
-Fivetran syncs on a schedule  --  every 5 minutes, every hour, every 24 hours. That means your warehouse data is always slightly stale. CorpusIQ queries live APIs on every request, so you always get the current state of your business.
+Fivetran syncs on a schedule  --  every 5 minutes, every hour, every 24 hours. That means your warehouse data is always slightly stale. CorpusIQ requests current provider data for each query; freshness follows provider behavior and any documented CorpusIQ caching.
 
 **Example:** You just closed a $50K deal in HubSpot. With CorpusIQ, an AI query 30 seconds later reflects that deal. With Fivetran, you wait until the next sync  --  potentially hours.
 

--- a/docs/corpusiq-vs-vector-databases.md
+++ b/docs/corpusiq-vs-vector-databases.md
@@ -63,7 +63,7 @@ CorpusIQ is designed for structured business data where accuracy, freshness, and
 | **Completeness** | Returns all matching records | Returns top-k similar results |
 | **Aggregation** | Native (SUM, COUNT, AVG via API) | Not supported |
 | **Setup** | 2-minute OAuth | Hours to days (chunking, embedding, indexing) |
-| **Data Movement** | None (queries source) | Full copy to vector store |
+| **Data path** | Direct MCP queries sources live; optional indexed search is separate | Full copy to vector store |
 | **Cost** | Per-seat subscription | Per-vector storage + compute |
 
 ## When Vector Databases Excel

--- a/docs/corpusiq-vs-zapier.md
+++ b/docs/corpusiq-vs-zapier.md
@@ -39,18 +39,18 @@ CorpusIQ and Zapier both connect business tools  --  but they do so in fundament
 | **Core Paradigm** | AI-native data access (MCP) | Event-driven workflow automation |
 | **Primary Use Case** | Natural-language business queries | Automating repetitive tasks |
 | **AI Integration** | Native (MCP protocol) | Limited (ChatGPT plugin, webhooks) |
-| **Data Flow** | Read-only, real-time query | Write/trigger actions between apps |
+| **Data Flow** | Retrieval and write-capable operations are separately named and annotated | Write/trigger actions between apps |
 | **Setup Time** | Under 2 minutes | 5-30 minutes per Zap |
 | **Real-Time Queries** | Yes  --  live, on-demand | No  --  event-triggered only |
 | **Cross-Source Analysis** | Multi-source queries in one prompt | Sequential Zaps with delays |
-| **Data Storage** | No replicated source-data warehouse; scoped operational logs up to 30 days | May store data in Zapier Tables |
+| **Data Storage** | Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may persist up to 30 days | May store data in Zapier Tables |
 | **Pricing Model** | Per-seat subscription | Per-task / per-Zap |
 
 ## How CorpusIQ Works
 
 CorpusIQ implements the **Model Context Protocol (MCP)**  --  an open standard developed by Anthropic that lets AI models discover and invoke tools. When you connect a data source to CorpusIQ (HubSpot, QuickBooks, Stripe, Google Analytics, etc.), the platform exposes that data as typed MCP tools that AI assistants can call.
 
-The AI never sees your raw data unless you ask it to  --  it sees structured function signatures and results, which it interprets and presents in natural language. Every query runs against the live source.
+The AI receives the tool definitions and results needed for the request. Retrieval requests current provider data; freshness follows provider behavior and documented CorpusIQ caching.
 
 ## How Zapier Works
 

--- a/docs/enterprise-ai-data-access.md
+++ b/docs/enterprise-ai-data-access.md
@@ -1,8 +1,8 @@
 ---
 title: "Enterprise AI Data Access: Security, SSO & Audit"
-description: "How enterprises can securely give AI access to business data with SSO/SAML, read-only OAuth, audit trails, live retrieval, and scoped retention."
+description: "How enterprises can securely give AI access to business data with SSO/SAML, read-only external-source retrieval, audit trails, live retrieval, and scoped retention."
 category: Enterprise Security
-tags: [Enterprise AI Data Access, SSO, SAML, SOC 2, CASA Tier 2, Data Residency, Audit Trails, Read-Only OAuth, Scoped Data Retention]
+tags: [Enterprise AI Data Access, SSO, SAML, SOC 2, CASA Tier 2, Data Residency, Audit Trails, Read-Only External-Source Retrieval, Scoped Data Retention]
 last_updated: 2026-07-08
 canonical: https://www.corpusiq.io/docs/enterprise-ai-data-access
 robots: index,follow
@@ -26,7 +26,7 @@ Giving an AI assistant access to enterprise business data sounds simple: connect
 
 - **Data residency.** Global enterprises should validate the complete processing path: storage, network transit, source-provider processing, the selected AI client, logs, and backups. Choosing a regional CorpusIQ deployment alone does not guarantee that every dependency remains in-region.
 
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Scoped direct-MCP retention.** External-source retrieval tools are marked read-only. The direct MCP path does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 
 - **Compliance certifications.** The solution must hold relevant certifications  --  SOC 2 Type II at minimum  --  and support the enterprise's own compliance frameworks including GDPR, CCPA, and industry-specific regulations.
 
@@ -46,7 +46,7 @@ CorpusIQ's enterprise AI data access architecture is built on five pillars:
 
 **Multi-factor authentication enforcement.** MFA is enforced at the identity provider level. CorpusIQ inherits the MFA policies already configured in Okta or Azure AD  --  including hardware token requirements, biometric authentication, and conditional access policies.
 
-**Per-user OAuth scoping.** When a user connects a data source through OAuth, the scopes granted are the minimum necessary for read-only business intelligence. Each user authenticates individually  --  there are no shared service accounts that would obscure who accessed what data.
+**Per-user OAuth scoping.** When a user connects a data source through OAuth, CorpusIQ requests provider scopes required for the documented operations. Retrieval and write-capable tools remain separately named and annotated regardless of provider scope grouping. Each user authenticates individually  --  there are no shared service accounts that would obscure who accessed what data.
 
 ### 2. Read-Only External Retrieval with Explicit Control-Plane Writes
 
@@ -54,13 +54,13 @@ CorpusIQ separates external-source retrieval from writes to user-declared Corpus
 
 - **Protocol level.** External-source retrieval tools carry read-only annotations. Explicit control-plane tools that update or remove user-declared facts, decisions, metric specifications, and source manifests carry separate non-read-only and destructive annotations where applicable.
 
-- **OAuth scope level.** External-source connectors request the documented retrieval scopes. For QuickBooks, `com.intuit.quickbooks.accounting.read`. For Shopify, `read_orders`, `read_products`, `read_customers`. For HubSpot, read-only access to contacts, deals, and companies.
+- **OAuth scope level.** External-source connectors request the provider scopes required for their documented operations. When a provider groups permissions into a broader scope, CorpusIQ still exposes retrieval and write-capable operations as separately named, safety-annotated tools.
 
-- **Connector level.** External-source connector implementations validate operations against a capability matrix and block write-back operations to connected vendor systems.
+- **Connector level.** External-source retrieval implementations validate operations against a capability matrix and block write-back. Write-capable connector operations, when exposed, are separately named and annotated.
 
 - **AI model level.** External connector descriptions identify retrieval behavior, while CorpusIQ control-plane descriptions state the supported state mutation explicitly.
 
-This defense-in-depth approach prevents external connector tools from writing back to connected vendor systems. Supported CorpusIQ control-plane mutations remain explicit, user-invoked, separately annotated, and auditable.
+This defense-in-depth approach keeps retrieval tools from writing back. Supported write-capable connector and CorpusIQ control-plane mutations remain explicit, separately named, and safety-annotated.
 
 ### 3. Comprehensive Audit Trails
 
@@ -93,13 +93,13 @@ Operational logs are protected from user edits and retained for up to 30 days un
 
 CorpusIQ's direct MCP path uses live retrieval with scoped operational retention:
 
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Scoped direct-MCP retention.** External-source retrieval tools are marked read-only. The direct MCP path does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 
 - **Direct-MCP index scope.** The direct path uses typed API calls and does not build embeddings or file indexes; optional indexed search is separate and retains embeddings plus minimal metadata until connector revocation or account deletion.
 
 - **Fresh direct queries.** Each direct MCP query requests current source data rather than serving a persisted full-response cache.
 
-- **No cross-tenant data mixing.** Each enterprise customer's queries are processed in isolated compute environments. Data from one customer is never co-located with data from another.
+- **Tenant isolation.** Authentication and token lookup are user-scoped; multi-tenant infrastructure does not imply shared authorization or cross-tenant result access.
 
 CorpusIQ stores encrypted authentication tokens and connector configuration while connections are active. Local AUDIT logs record raw query text and tool parameters plus bounded result summaries; the Azure Log Analytics workspace retains those logs for 30 days. Optional indexed search has a separate embeddings and minimal-metadata lifecycle.
 
@@ -139,7 +139,7 @@ CorpusIQ provides this stack  --  50+ enterprise connectors, SSO integration, RB
 
 **Step 1: SSO configuration.** Integrate CorpusIQ with your identity provider (Okta, Azure AD, Ping Identity, etc.) through SAML 2.0 or OpenID Connect. Configure role mappings to your existing directory groups. Typical setup: 1–2 hours with your IT team.
 
-**Step 2: Data source connections.** Business users connect their platforms through OAuth. Each connection is scoped to read-only access by default. The user sees exactly which permissions are being granted and can revoke access at any time. Typical setup: 2–5 minutes per data source.
+**Step 2: Data source connections.** Business users connect their platforms through OAuth. Provider scopes vary by connector and documented operation; retrieval and write-capable tools remain separately named and annotated. Typical setup: 2–5 minutes per data source.
 
 **Step 3: Department-level governance.** Administrators configure which roles can access which data sources. Marketing connects its analytics stack. Finance connects its accounting platforms. Sales connects its CRM. Cross-department queries respect these boundaries  --  a marketing user cannot accidentally query financial data.
 
@@ -172,7 +172,7 @@ A: CorpusIQ maintains a SOC 2 aligned security posture and is CASA Tier 2 certif
 A: Through role-based access control (RBAC) mapped to your existing directory groups. Each role has specific data source permissions. OAuth connections are per-user, so each user authenticates individually and inherits their own permissions from the source platform.
 
 **Q: Can CorpusIQ write data to our business systems?**
-A: Connected third-party business systems are read-only by design. Explicit CorpusIQ control-plane tools may update or remove user-declared facts, decisions, metric specifications, and source manifests, but they do not write back to connected source systems.
+A: External-source retrieval tools do not write back. Write-capable connector and CorpusIQ control-plane tools are separately named and safety-annotated.
 
 **Q: Where is CorpusIQ infrastructure located, and can we control data residency?**
 A: Enterprise customers can request a deployment region, subject to validation of storage, network transit, source-provider processing, the selected AI client, logs, and backups. Contact sales@corpusiq.io for a customer-specific residency assessment.
@@ -206,7 +206,7 @@ A: Yes. CorpusIQ's enterprise offering includes support for custom MCP connector
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Enterprise AI Data Access: Security, SSO, Audit Trails, and Compliance",
-  "description": "How enterprises can securely give AI access to business data: SSO/SAML, SOC 2, CASA Tier 2, data residency, read-only OAuth, audit trails, and scoped direct-MCP retention.",
+  "description": "How enterprises can securely give AI access to business data: SSO/SAML, SOC 2, CASA Tier 2, data residency, read-only external-source retrieval, audit trails, and scoped direct-MCP retention.",
   "author": {"@type": "Organization", "name": "CorpusIQ"},
   "datePublished": "2026-06-16"
 }

--- a/docs/how-mcp-servers-work.md
+++ b/docs/how-mcp-servers-work.md
@@ -205,7 +205,7 @@ CorpusIQ's authentication model:
 
 **OAuth 2.0 for cloud services.** Each business platform (Shopify, QuickBooks, HubSpot, etc.) is connected through OAuth 2.0. Users authorize CorpusIQ to access their data with explicitly scoped permissions. Tokens are stored encrypted at rest and rotated automatically.
 
-**Read-only by default.** Every connector defaults to read-only access. Write operations require explicit opt-in at both the OAuth scope level and the MCP server configuration level. This dual-gate approach prevents accidental data modification.
+**Operation-level safety metadata.** External-source retrieval tools carry read-only annotations. Write-capable connector-management and CorpusIQ control-plane tools are separately named and annotated for their actual behavior.
 
 **Token isolation.** Each user's OAuth tokens are cryptographically isolated. No user can access another user's data, even within the same CorpusIQ organization.
 

--- a/docs/how-to-analyze-quickbooks-with-ai.md
+++ b/docs/how-to-analyze-quickbooks-with-ai.md
@@ -33,7 +33,7 @@ Whether you're a business owner checking financial health, an accountant prepari
 Before diving into analysis, you need to connect QuickBooks to an AI assistant through CorpusIQ's MCP platform. Here's the setup process:
 
 ### 1. Connect QuickBooks to CorpusIQ
-Navigate to your CorpusIQ dashboard and select "Connect QuickBooks." Sign in on Intuit's OAuth page and authorize the read-only connection. Direct MCP requests then fetch QuickBooks records live; CorpusIQ does not retain raw customer files or full connector response payloads. Operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+Navigate to your CorpusIQ dashboard and select "Connect QuickBooks." Sign in on Intuit's OAuth page and review and approve the provider scopes. Direct MCP requests then fetch QuickBooks records live; CorpusIQ does not retain raw customer files or full connector response payloads. Operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 
 ### 2. Configure Your AI Assistant
 CorpusIQ supports both ChatGPT and Claude as AI backends. Choose based on your analysis needs:

--- a/docs/hubspot-business-intelligence.md
+++ b/docs/hubspot-business-intelligence.md
@@ -34,7 +34,7 @@ last_updated: "2026-08-12"
 
 HubSpot is one of the world's most widely adopted CRM platforms, used by over 200,000 businesses to manage contacts, deals, companies, and customer relationships. But while HubSpot excels at storing and organizing data, extracting real-time business intelligence from that data often requires exporting to spreadsheets, building custom dashboards, or relying on HubSpot's built-in reporting  --  which, while capable, can't answer free-form business questions in natural language.
 
-CorpusIQ changes that. Using the **Model Context Protocol (MCP)**  --  the open standard for connecting data to AI  --  CorpusIQ enables any MCP-compatible AI assistant to query your HubSpot CRM live, in real time, without moving, copying, or duplicating your data.
+CorpusIQ changes that. Using the **Model Context Protocol (MCP)**  --  the open standard for connecting data to AI  --  CorpusIQ enables any MCP-compatible AI assistant to query HubSpot through live retrieval. Direct MCP does not retain raw customer files or full connector response payloads; operational logs and optional indexed search follow their published lifecycles.
 
 ## How It Works
 

--- a/docs/hubspot-dashboard-with-chatgpt.md
+++ b/docs/hubspot-dashboard-with-chatgpt.md
@@ -50,7 +50,7 @@ Different stakeholders need different views:
 - **Sales Ops Dashboard**: Deal hygiene, process adherence, data quality, system health
 
 ### 3. Real-Time Data Refresh
-Every dashboard pull queries HubSpot live. If a rep updated a deal 30 seconds ago, it's reflected in your dashboard now. No batch delays, no cache staleness, no waiting for overnight refreshes. This is critical during end-of-quarter when deal statuses change minute by minute.
+Every dashboard pull queries HubSpot live. If a rep updated a deal 30 seconds ago, it's reflected in your dashboard now. Queries request current HubSpot data. Freshness follows HubSpot and CorpusIQ cache behavior. This is critical during end-of-quarter when deal statuses change minute by minute.
 
 ### 4. Intelligent Alerting
 ChatGPT doesn't just display numbers  --  it interprets them against your targets and historical patterns. "Pipeline coverage is 2.8x, below our 3x target. However, the shortfall is concentrated in early-stage pipeline  --  late-stage coverage is healthy at 1.4x. Recommended action: focus reps on prospecting this week." Context-aware alerts make dashboards actionable, not just informational.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ robots: "index,follow"
 A: CorpusIQ is a private AI acceleration layer that connects 40+ business tools (HubSpot, QuickBooks, Stripe, Shopify, GA4, Slack, and more) to ChatGPT, Claude, and AI agents via the Model Context Protocol (MCP). It enables real-time, natural-language queries across your data stack without storing raw customer files or full connector response payloads.
 
 **Q: How does CorpusIQ connect my business data to AI?**  
-A: CorpusIQ uses MCP (Model Context Protocol)  --  an open standard that lets AI assistants discover and use external tools. Connect your data sources via OAuth, and the AI can query them live through CorpusIQ's MCP endpoint with read-only access.
+A: CorpusIQ uses MCP (Model Context Protocol)  --  an open standard that lets AI assistants discover and use external tools. Connect your data sources through their documented authorization flows, and the AI can invoke CorpusIQ tools with operation-specific names and safety annotations.
 
 **Q: What data sources does CorpusIQ support?**  
 A: CorpusIQ supports 40+ business tools including HubSpot, Salesforce, QuickBooks, Stripe, Shopify, GA4, Google Ads, Meta Ads, Slack, Gmail, Google Drive, Notion, PostgreSQL, MSSQL, MongoDB, and more  --  see the full connectors directory.

--- a/docs/mcp-for-ecommerce.md
+++ b/docs/mcp-for-ecommerce.md
@@ -101,7 +101,7 @@ Ecommerce success depends on understanding customers:
 
 **Unified connector library.** CorpusIQ connects to Shopify, Amazon, eBay, Klaviyo, Mailchimp, Google Ads, Meta Ads, Google Analytics, QuickBooks, Stripe, and more  --  all through a single MCP server.
 
-**Read-only access.** All ecommerce connectors default to read-only. You can analyze order data, inventory levels, and customer information without any risk of modifying products, orders, or settings.
+**Explicit operation boundaries.** Ecommerce retrieval tools are marked read-only. Write-capable connector-management and CorpusIQ control-plane operations are separately named and safety-annotated.
 
 **Real-time queries.** Ask about today's orders and get today's data  --  not yesterday's export. Critical for inventory decisions, fulfillment monitoring, and flash sale performance tracking.
 
@@ -138,7 +138,7 @@ Yes. Connect Amazon advertising data alongside order data to analyze which campa
 <details>
 <summary><strong>Is this secure for my store data?</strong></summary>
 
-Yes. All connections use OAuth with read-only scopes. CorpusIQ cannot modify your products, orders, or customer data. Connected commerce platforms remain authoritative; direct-MCP and operational-log retention follow the published lifecycles.
+Provider scopes vary by connection. The ecommerce retrieval tools documented here do not write products, orders, or customer records back to their sources; write-capable management/control-plane operations are separate. Connected commerce platforms remain authoritative, and retention follows the published lifecycles.
 </details>
 
 <details>

--- a/docs/mcp-for-small-business.md
+++ b/docs/mcp-for-small-business.md
@@ -39,7 +39,7 @@ The setup process for a small business using CorpusIQ:
 
 **1. Create an account.** Sign up through the CorpusIQ platform. No credit card required to start.
 
-**2. Connect QuickBooks.** Authorize CorpusIQ to access your QuickBooks data through OAuth. The connection is read-only by default  --  CorpusIQ can read your financial data but cannot modify it.
+**2. Connect QuickBooks.** Authorize CorpusIQ to access your QuickBooks data through OAuth. The advertised financial-data retrieval tools are marked read-only. Write-capable tools, when available, are separately named and annotated.
 
 **3. Connect your CRM.** Authorize HubSpot, Salesforce, or your preferred CRM. Again, read-only access for querying contacts, deals, and pipeline data.
 

--- a/docs/mcp-security-best-practices.md
+++ b/docs/mcp-security-best-practices.md
@@ -16,7 +16,7 @@ Security is the first question every business leader asks about AI data integrat
 
 MCP's security model rests on several architectural decisions:
 
-**Read-only by default.** The protocol itself supports both read and write operations, but the secure default  --  and the approach CorpusIQ takes  --  is to implement all business intelligence connectors as read-only. The AI model can query data but cannot modify it.
+**Operation-level safety.** MCP supports reads and writes. CorpusIQ marks external-source retrieval tools read-only and exposes write-capable connector-management and CorpusIQ control-plane tools separately with behavior-matched annotations.
 
 **OAuth 2.0 authentication.** Every connection to a third-party platform uses OAuth 2.0, the industry standard for delegated authorization. Users grant CorpusIQ specific, scoped permissions rather than sharing credentials.
 
@@ -31,10 +31,10 @@ CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain
 OAuth 2.0 scopes determine what an MCP server can do with a connected platform. Best practice is to request the minimum scopes necessary for the intended use case.
 
 CorpusIQ's approach:
-- **Read-only scopes by default.** For QuickBooks, we request `com.intuit.quickbooks.accounting.read`  --  not the broader scope that includes write access. For Shopify, we request `read_orders`, `read_products`, `read_customers`  --  not `write_orders` or `write_products`.
-- **Explicit opt-in for write operations.** If a use case requires write access (for example, creating draft invoices), the user must explicitly approve additional scopes. This is a deliberate friction point  --  it ensures write access is never granted accidentally.
-- **Per-connector scope configuration.** Each connected platform has independently configured scopes. Granting write access to your email marketing platform doesn't grant write access to your accounting system.
-- **Scope visibility.** Users can see exactly which scopes are granted to each connection at any time through the CorpusIQ dashboard.
+- **Source-specific scopes.** CorpusIQ requests the provider scopes needed for each documented operation. Read-only retrieval tools and write-capable connector-management or control-plane tools remain separately named and safety-annotated even when a provider groups permissions into broader scopes.
+- **Explicit operation boundaries.** Read-only retrieval tools and write-capable connector-management or CorpusIQ control-plane tools are separately named and carry explicit safety annotations.
+- **Per-connector scope configuration.** Each connected platform has independently configured scopes. One connector's authorization does not widen another connector's access.
+- **Scope visibility.** The provider authorization screen displays the requested source scopes. CorpusIQ tool names and annotations disclose whether each published operation is read-only or write-capable.
 
 ## Token Management
 
@@ -50,19 +50,19 @@ OAuth tokens are the keys to your data. Managing them securely is critical:
 
 **Cross-user isolation.** Each user's tokens are cryptographically isolated. User A's Shopify token cannot be used to access User B's data, even if both users are in the same CorpusIQ organization. This isolation extends to the database layer  --  tokens are stored with user-scoped encryption keys.
 
-## Read-Only Architecture Deep Dive
+## Tool Boundary Architecture Deep Dive
 
-The read-only default deserves deeper examination because it's the most important security property of the system.
+The distinction between read-only retrieval and write-capable CorpusIQ-owned state changes deserves deeper examination.
 
-**Protocol-level enforcement.** CorpusIQ's MCP server validates every tool call against a capability matrix. Tools marked as read-only cannot be used to execute write operations, regardless of what OAuth scopes are granted.
+**Protocol-level enforcement.** CorpusIQ's MCP server validates every tool call against a capability matrix. Tools marked as read-only cannot execute write operations. Write-capable connector-management and control-plane tools are separately named and annotated.
 
-**API-level guardrails.** Even with write OAuth scopes, CorpusIQ's connector implementations include additional validation. An API call that would modify data is blocked at the connector level unless the connector is explicitly configured to allow writes.
+**API-level guardrails.** Connector implementations validate the requested operation and source-specific authorization. A write-capable tool can execute only its declared action; it does not silently widen a read-only retrieval call.
 
-**AI model guardrails.** The MCP tool definitions presented to the AI model describe read-only capabilities. The model sees "List Shopify Orders"  --  not "Create Shopify Order." This means the AI model itself cannot request write operations unless they've been explicitly exposed.
+**AI-client visibility.** MCP tool definitions expose operation-specific names, descriptions, schemas, and safety annotations. Clients can distinguish retrieval tools from write-capable connector-management and CorpusIQ control-plane tools before invocation.
 
-**Human approval for writes.** In the rare cases where write operations are enabled, CorpusIQ can require human confirmation before execution. The AI model proposes the action, and a human user must approve it before the MCP server executes it.
+**Invocation remains explicit.** A write-capable operation runs only when that separately named tool is invoked with valid parameters and authorization. Client confirmation behavior is governed by the selected AI client's interface and policy.
 
-This defense-in-depth approach  --  protocol, API, AI model, and human approval  --  means that write operations require multiple deliberate choices to enable. Accidental data modification is architecturally prevented.
+This defense-in-depth approach makes write-capable operations visible and bounded. It reduces unintended-change risk without claiming that modification is architecturally impossible.
 
 ## Audit Trails
 

--- a/docs/mcp-vs-api-integrations.md
+++ b/docs/mcp-vs-api-integrations.md
@@ -125,7 +125,7 @@ Key CorpusIQ features that go beyond raw API access:
 
 **Canonical definitions.** Declare how key business terms should be interpreted, and the AI model applies those definitions consistently across all data sources.
 
-**Read-only guardrails.** Every connector defaults to read-only. No accidental data modification, no matter what the AI model requests.
+**Explicit tool boundaries.** External-source retrieval tools are marked read-only. Write-capable connector-management and CorpusIQ control-plane operations are separately named and safety-annotated.
 
 **Audit trail.** Every tool call is logged, giving you complete visibility into what data was accessed and when.
 
@@ -146,7 +146,7 @@ Yes. MCP tool definitions include rich parameter schemas that support pagination
 <details>
 <summary><strong>What if I need to write data, not just read it?</strong></summary>
 
-MCP supports write operations, but CorpusIQ defaults to read-only for safety. Write operations require explicit opt-in. For most business intelligence use cases, read-only is exactly what you need.
+A: MCP supports both reads and writes. CorpusIQ exposes retrieval and write-capable operations as separately named tools with behavior-matched safety annotations.
 </details>
 
 <details>

--- a/docs/mcp-vs-zapier.md
+++ b/docs/mcp-vs-zapier.md
@@ -106,7 +106,7 @@ Not entirely  --  they serve different purposes. Zapier excels at automated acti
 <details>
 <summary><strong>Does MCP support triggering actions?</strong></summary>
 
-The base MCP protocol supports write operations, but CorpusIQ defaults to read-only for data safety. For automation workflows that require write operations, Zapier or Make are better choices today. CorpusIQ focuses on the intelligence layer.
+The base MCP protocol supports reads and writes. CorpusIQ marks external-source retrieval tools read-only and exposes write-capable management/control-plane operations separately; Zapier and Make remain focused on multi-step vendor automation.
 </details>
 
 <details>

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -28,7 +28,7 @@ Create an account at [corpusiq.io/register](https://corpusiq.io/register). You c
 3. Click **Add Connection** on any service you want to connect
 4. Complete the OAuth authorization flow
 
-CorpusIQ uses **read-only OAuth scopes**  --  it can search your data but never modify it. The exact permissions are displayed on the authorization screen.
+Provider scopes vary by connector and are displayed on the authorization screen. External-source retrieval tools are marked read-only; write-capable management/control-plane tools are separately named and annotated.
 
 Popular first connections:
 - **Gmail**  --  Search your email history
@@ -114,7 +114,6 @@ curl -X POST https://mcp2.corpusiq.io/mcp \
 curl -X POST https://mcp2.corpusiq.io/mcp \
   -H "Authorization: Bearer $CORPUSIQ_TOKEN" \
   -H "Content-Type: application/json" \
-  -H "Idempotency-Key: $(uuidgen)" \
   -d '{"query": "How many HubSpot deals closed this quarter?"}'
 ```
 

--- a/docs/quickbooks-dashboard-with-chatgpt.md
+++ b/docs/quickbooks-dashboard-with-chatgpt.md
@@ -52,7 +52,7 @@ Through CorpusIQ, you define what matters to your business. Create dashboard tem
 - **Operations Dashboard**: Expense trends, vendor spend, inventory metrics
 
 ### 3. Real-Time Data Refresh
-Every dashboard pull queries QuickBooks live  --  there's no stale cache. The numbers you see reflect the current state of your books, not last week's export. This is critical for cash flow monitoring and AR management where hour-level freshness matters.
+Dashboard pulls query QuickBooks at request time. Freshness follows QuickBooks and CorpusIQ cache behavior, so verify time-sensitive figures against the cited source record.
 
 ### 4. Anomaly Highlighting
 ChatGPT doesn't just present numbers  --  it flags what needs attention. "Your gross margin dropped 3.2 percentage points this month  --  the largest one-month decline in 18 months. The primary driver was a 15% increase in COGS for the Widget product line." These contextual alerts turn raw data into actionable intelligence.

--- a/docs/search/README.md
+++ b/docs/search/README.md
@@ -15,7 +15,7 @@ CorpusIQ provides natural language search across all 36 connected business data 
 
 - Natural language queries (no SQL required)
 - Cross-source search (query Stripe AND Shopify in one question)
-- Real-time results (no cached or stale data)
+- Live source queries; provider and transport caching behavior may vary
 - Date range filtering
 - Aggregation and summarization
 - Trend analysis

--- a/docs/secure-ai-data-connectivity.md
+++ b/docs/secure-ai-data-connectivity.md
@@ -2,7 +2,7 @@
 title: "Secure AI Data Connectivity -- Zero-Trust Business AI"
 description: Connect AI assistants to authorized business data with scoped OAuth, encrypted transport, explicit retention classes, and source-aware results. CASA Tier 2 certified.
 category: Security
-tags: [secure AI connectivity, zero-trust AI, business AI security, read-only OAuth, MCP security, encrypted AI access, AI data governance]
+tags: [secure AI connectivity, zero-trust AI, business AI security, read-only external-source retrieval, MCP security, encrypted AI access, AI data governance]
 last_updated: "2026-08-14"
 canonical: https://www.corpusiq.io/docs/secure-ai-data-connectivity
 robots: index,follow

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,6 @@
 ---
 title: "CorpusIQ Security"
-description: "CorpusIQ security documentation: CASA Tier 2, SOC 2 aligned controls, AES-256, TLS 1.3, read-only OAuth, and scoped data handling"
+description: "CorpusIQ security documentation: CASA Tier 2, SOC 2 aligned controls, AES-256, TLS 1.3, read-only external-source retrieval, and scoped data handling"
 category: "Documentation"
 tags: ["corpusiq security", "soc 2", "casa tier 2", "data privacy", "encryption", "oauth security", "gdpr compliance", "ai security"]
 last_updated: "2026-08-12"
@@ -75,12 +75,12 @@ CorpusIQ processes data under the lawful basis of user consent and legitimate in
 - **Data Minimization:** Only data necessary to answer a query is retrieved
 - **Purpose Limitation:** Retrieved records fulfill the user's request; retained operational metadata supports service security, reliability, and compliance under the published schedule
 - **No Data Sale:** CorpusIQ does not sell or monetize user data; scoped data is shared only with processors required to fulfill the request
-- **No CorpusIQ Model Training:** CorpusIQ does not use customer data to train models; each selected AI client's policy applies to its conversation
+- **No CorpusIQ Model Training:** CorpusIQ does not use customer data to train models; conversation handling follows the selected AI provider's plan and settings
 - **No Background Collection:** Every API call to a connected tool is triggered by an explicit user query. There is no periodic syncing or scheduled polling.
 
 ## 5. Retention and Deletion
 
-1. A query is received and translated into read-only API calls
+1. A query is received and routed to the separately named operations required for the request
 2. Results are fetched from connected tools in real time
 3. Direct MCP requests return the result without building embeddings or file indexes; optional indexed search separately retains embeddings and minimal metadata
 4. Optional indexed-search features may retain embeddings and minimal metadata while the connector remains active
@@ -89,7 +89,7 @@ To request deletion of account data, contact privacy@corpusiq.io. CorpusIQ respo
 
 ## 6. Subprocessors
 
-Infrastructure: Microsoft Azure (US-based). Enterprise cloud infrastructure. For enterprise customers, data residency options are available  --  contact sales@corpusiq.io.
+Infrastructure: Microsoft Azure (US-based). Residency requirements must be validated against the complete customer-specific processing path, including source providers, selected AI clients, logs, and backups.
 
 ## 7. Incident Response
 
@@ -127,7 +127,7 @@ If you discover a security vulnerability, report to security@corpusiq.io. We fol
 ## Frequently Asked Questions
 
 **Q: What security certifications does CorpusIQ hold?**  
-A: CorpusIQ is CASA Tier 2 certified by DEKRA (OWASP Top 10 verified) and maintains a SOC 2 aligned security posture. The platform uses AES-256 encryption at rest, TLS 1.3 in transit, and read-only OAuth for all data source connections.
+A: CorpusIQ is CASA Tier 2 certified by DEKRA (OWASP Top 10 verified) and maintains a SOC 2 aligned security posture. The platform uses AES-256 encryption at rest, TLS 1.3 in transit, and operation-level safety annotations for retrieval and write-capable tools.
 
 **Q: Does CorpusIQ store my business data?**  
 A: Direct MCP requests retrieve source records live without retaining raw customer files or full connector response payloads. Operational query text, tool-call metadata, and bounded outcome summaries are retained for up to 30 days. Optional indexed-search features may retain embeddings and minimal metadata while the connector remains active.
@@ -136,7 +136,7 @@ A: Direct MCP requests retrieve source records live without retaining raw custom
 A: Contact privacy@corpusiq.io to request deletion of account data. CorpusIQ responds to privacy requests within 30 days. Operational MCP query logs remain subject to the 30-day Azure Log Analytics retention window.
 
 **Q: Where is CorpusIQ infrastructure hosted?**  
-A: Infrastructure runs on Microsoft Azure (US-based). Enterprise customers can request data residency options for specific geographic regions. Contact sales@corpusiq.io for details.
+A: Infrastructure runs on Microsoft Azure. Regional deployment terms are not part of the current public contract; contact sales@corpusiq.io for current availability.
 
 **Q: How do I report a security vulnerability?**  
 A: Report to security@corpusiq.io. CorpusIQ follows coordinated disclosure and aims to acknowledge reports within 24 hours. Do not publicly disclose before the team has addressed the issue.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -12,7 +12,7 @@ tags: ["hermes agent", "ai agent", "documentation"]
 ---
 
 title: "CorpusIQ Security Overview  --  Authentication, Encryption, and Read-Only Access"
-description: "CorpusIQ security overview: OAuth 2.0 authentication for agents and chat users, TLS 1.3 encryption, read-only data access policy, audit logging, data handling, and security best practices."
+description: "CorpusIQ security overview: OAuth 2.0 authentication, operation-level permissions, encryption, audit logging, data handling, and security best practices."
 category: "Documentation"
 tags: ["corpusiq security overview", "authentication", "encryption", "read-only access", "oauth security", "data handling", "audit logging"]
 last_updated: "2026-08-12"
@@ -21,7 +21,7 @@ robots: "index,follow"
 ---
 # Security
 
-CorpusIQ is designed with security as a foundational requirement. External-source connector access is read-only and does not write back to vendor systems. Explicit CorpusIQ control-plane tools can update or remove user-declared CorpusIQ state and carry separate safety annotations.
+CorpusIQ is designed with security as a foundational requirement. External-source retrieval tools are marked read-only. Write-capable connector and CorpusIQ control-plane tools are separately named and carry behavior-matched safety annotations.
 
 ## Authentication
 
@@ -35,18 +35,18 @@ CorpusIQ is designed with security as a foundational requirement. External-sourc
 - No browser required for ongoing agent access
 - Refresh token rotation
 - Device verification prevents unauthorized access
-- Tokens can be revoked from the dashboard at any time
+- Dashboard disconnect removes CorpusIQ connection state and requires reauthorization before reuse; provider authorization remains provider-governed
 
 ### Data Source Connections
 - OAuth 2.0 authorization for each connected source
 - Scoped access: CorpusIQ requests minimum required permissions
-- Connections can be revoked individually
-- No raw API keys stored or exposed
+- CorpusIQ connections can be disconnected individually
+- Credential-based connectors store required secrets encrypted; public responses do not expose them
 
 ## Data Access
 
 ### Scoped Access Policy
-External-source connector tools use read-only retrieval: they query connected sources, normalize results, and do not write back to those vendor systems or initiate vendor transactions. Explicit CorpusIQ control-plane tools can update or remove user-declared facts, decisions, metric specifications, and source manifests and carry separate safety annotations.
+External-source retrieval tools query connected sources, normalize results, and do not write back. Write-capable connector and CorpusIQ control-plane tools are separately named and carry behavior-matched safety annotations.
 
 ### Data Handling
 - Direct MCP retrieves source records on demand and delivers scoped results to the requesting client
@@ -82,7 +82,7 @@ Report security concerns to security@corpusiq.io. We respond within 24 hours.
 ## Frequently Asked Questions
 
 **Q: How does CorpusIQ authenticate users?**  
-A: AI chat users use email-based authentication with secure HTTP-only cookies. AI agent users use OAuth 2.0 Device Authorization Grant (RFC 8628) with refresh token rotation. Data source connections use OAuth 2.0 with scoped, read-only permissions.
+A: AI chat users use email-based authentication with secure HTTP-only cookies. AI agent users use OAuth 2.0 Device Authorization Grant (RFC 8628) with refresh token rotation. Data-source provider scopes vary by connector and documented operation.
 
 **Q: Is CorpusIQ data access read-only?**
 A: External-source retrieval is read-only and does not write back to connected vendor systems. Explicit CorpusIQ control-plane tools can modify user-declared CorpusIQ state and are separately annotated.

--- a/docs/shopify-dashboard-with-chatgpt.md
+++ b/docs/shopify-dashboard-with-chatgpt.md
@@ -143,7 +143,7 @@ Shopify's dashboard shows a fixed set of widgets with limited customization and 
 Yes. Through CorpusIQ, schedule dashboard delivery via email, Slack, or file storage (Google Drive, OneDrive, Dropbox). "Send me the morning dashboard at 8 AM daily" or "Deliver the weekly performance report to the ecommerce Slack channel every Monday at 9 AM."
 
 ### How current is the dashboard data?
-Live. Every dashboard query fetches data from Shopify's API in real time at the moment you ask. There's no batch processing, no cache delay, no ETL window. If an order just came in, it's reflected.
+Dashboard queries request current Shopify data. Freshness follows Shopify and CorpusIQ cache behavior; verify time-sensitive orders against the cited source record.
 
 ### Can multiple team members have their own dashboards?
 Yes. Each team member can have personalized dashboard templates. Marketing sees marketing KPIs. Operations sees fulfillment metrics. The CEO sees the executive summary. All draw from the same live Shopify data.

--- a/docs/what-is-an-mcp-server.md
+++ b/docs/what-is-an-mcp-server.md
@@ -26,7 +26,7 @@ An MCP server is a lightweight program that sits between an AI model and your da
 
 The server then executes the request against your live data  --  your Shopify store, your Salesforce CRM, your Google Analytics  --  and returns structured results the AI can understand and explain in natural language.
 
-Critically, MCP servers are **read-only by design** for business intelligence use cases. They don't modify data, create records, or execute destructive operations unless explicitly configured to do so. This architecture makes MCP inherently safer than traditional API integrations, where a misconfigured call could modify production data.
+MCP servers advertise operation-level annotations rather than a universal read-only guarantee. CorpusIQ marks external-source retrieval tools read-only and separately names and annotates write-capable and control-plane operations.
 
 ## How Tool Discovery Works
 
@@ -74,13 +74,13 @@ CorpusIQ's MCP implementation adds critical enterprise features on top of the ba
 
 **Unified authentication**  --  connect all your data sources once through OAuth, not once per server
 **Cross-source queries**  --  ask questions that span multiple data sources in a single conversation
-**Read-only guardrails**  --  every connector defaults to read-only, with explicit opt-in for write operations
+**Operation-level guardrails**  --  retrieval and write-capable operations use separate names and behavior-matched safety annotations
 **Audit logging**  --  every tool call is logged for compliance and debugging
 **Canonical facts**  --  declare business definitions once and have them applied consistently across all queries
 
 ## How It Works: A Step-by-Step Walkthrough
 
-**Step 1: Connection.** You connect your business data sources to CorpusIQ through OAuth. Each connection is scoped to read-only access by default. CorpusIQ stores your tokens securely and never shares them with third parties.
+**Step 1: Connection.** You connect business data sources through provider authorization. Provider scopes vary by documented operation; retrieval and write-capable tools are separately named and annotated. CorpusIQ stores required credentials encrypted and does not expose them in tool responses.
 
 **Step 2: Discovery.** When you start a conversation with an MCP-enabled AI assistant, the client queries your CorpusIQ MCP server and discovers every available tool  --  "list Shopify orders," "get QuickBooks profit and loss," "search HubSpot contacts," and hundreds more.
 

--- a/examples/cross-source-roas-analysis.md
+++ b/examples/cross-source-roas-analysis.md
@@ -75,7 +75,7 @@ Traditional ROAS analysis requires:
 - Building a spreadsheet with VLOOKUPs
 - Manual updates every time you want to check
 
-With CorpusIQ, it's one question. Every time. The data is always live.
+With CorpusIQ, it's one question. Every time. The analysis requests current provider data; freshness follows each provider and CorpusIQ cache behavior.
 
 ## Next Steps
 

--- a/governance/README.md
+++ b/governance/README.md
@@ -19,7 +19,7 @@ Enterprise plans include full audit logging:
 ## Data Policies
 
 - **Scoped retention** — Direct MCP does not retain raw customer files or full connector response payloads; operational logs may persist for up to 30 days
-- **No CorpusIQ model training** — CorpusIQ does not use customer data to train models; the selected AI client's policy applies to its conversation
+- **No CorpusIQ model training** — CorpusIQ does not use customer data to train models; conversation handling follows the selected AI provider's plan and settings
 - **Connector-level permissions** — Each data source has its own OAuth scope
 
 ## Enterprise

--- a/hermes/architecture/harness-beats-model.md
+++ b/hermes/architecture/harness-beats-model.md
@@ -40,7 +40,7 @@ This insight applies directly to business intelligence. Your AI cannot answer yo
 
 ChatGPT is strong enough to calculate margins, forecast cash flow, and analyze trends. It cannot reach your QuickBooks. It cannot query your Shopify. It cannot pull from your Stripe. The model is ready. The harness does not exist.
 
-CorpusIQ is that harness for business data. The connector layer. The read-only OAuth. The metric definitions. The source citations. The cross-AI compatibility. This is the harness that turns a general-purpose AI into a business operating system.
+CorpusIQ is that harness for business data. The connector layer. The read-only external-source retrieval. The metric definitions. The source citations. The cross-AI compatibility. This is the harness that turns a general-purpose AI into a business operating system.
 
 ## The Industry Shift
 

--- a/hermes/architecture/harness-wars-ai-infrastructure.md
+++ b/hermes/architecture/harness-wars-ai-infrastructure.md
@@ -28,7 +28,7 @@ Three things happened in 2026 that shifted the competitive landscape:
 
 In coding agents, the harness manages tools, context, memory, and verification. In business AI, the harness does the same thing for business data:
 
-**Tools**: Connectors to Shopify, QuickBooks, Stripe, HubSpot, GA4, and 35 more business platforms. Each with read-only OAuth. Each authenticating independently.
+**Tools**: Connectors to Shopify, QuickBooks, Stripe, HubSpot, GA4, and 35 more business platforms. Each with read-only external-source retrieval. Each authenticating independently.
 
 **Context**: Metric definitions that mean the same thing across every AI and every tool. Revenue defined once. Applied everywhere. No reconciliation required.
 

--- a/hermes/architecture/mismanaged-geniuses-hypothesis.md
+++ b/hermes/architecture/mismanaged-geniuses-hypothesis.md
@@ -36,7 +36,7 @@ A proper harness for business AI is not a dashboard. It is not a CSV export. It 
 
 It is:
 
-**Connectors that reach your actual tools.** Shopify for orders. Stripe for payments. QuickBooks for financials. HubSpot for CRM. GA4 for analytics. Each with read-only OAuth. Each authenticating independently.
+**Connectors that reach your actual tools.** Shopify for orders. Stripe for payments. QuickBooks for financials. HubSpot for CRM. GA4 for analytics. Each with read-only external-source retrieval. Each authenticating independently.
 
 **Metric definitions that mean the same thing everywhere.** Revenue defined once. Applied across every AI. Same number in ChatGPT, Claude, and Perplexity. Every time.
 

--- a/hermes/architecture/read-only-oauth-ai-business-tools.md
+++ b/hermes/architecture/read-only-oauth-ai-business-tools.md
@@ -1,6 +1,6 @@
 ---
-title: "Read-Only OAuth: Why AI Should Never Write to Your"
-description: "Setup and usage guide for Read-Only OAuth: Why AI Should Never Write to Your Business Tools. Part of the Hermes resource directory."
+title: "Read-Only External-Source Retrieval: Why AI Should Never Write to Your"
+description: "Setup and usage guide for Read-Only External-Source Retrieval: Why AI Should Never Write to Your Business Tools. Part of the Hermes resource directory."
 last_updated: 2026-08-12
 canonical: "https://www.corpusiq.io/docs/hermes/architecture/read-only-oauth-ai-business-tools/"
 robots: "index,follow"
@@ -8,7 +8,7 @@ tags: ["hermes agent", "ai agent", "nous research"]
 
 ---
 
-# Read-Only OAuth: Why AI Should Never Write to Your Business Tools
+# Read-Only External-Source Retrieval: Why AI Should Never Write to Your Business Tools
 
 Every business tool you use contains data that should never be modified by AI. Your QuickBooks general ledger. Your Shopify orders. Your Stripe transactions. Your HubSpot CRM records.
 
@@ -28,7 +28,7 @@ Write access risks include:
 
 **Security exposure**: Write access is a broader attack surface. If an AI with write access is compromised, every tool it can write to is compromised.
 
-## How Read-Only OAuth Works
+## How Read-Only External-Source Retrieval Works
 
 Read-only OAuth gives AI permission to query data but blocks all write operations. The authorization flow is:
 
@@ -41,7 +41,7 @@ Even if the AI tries to modify data, the tool itself blocks the operation. The b
 
 ## Per-Source Authentication
 
-Each tool gets its own read-only OAuth token. Shopify has one token. QuickBooks has another. Stripe has a third. No shared credentials. No master key.
+Each tool gets its own read-only external-source retrieval token. Shopify has one token. QuickBooks has another. Stripe has a third. No shared credentials. No master key.
 
 This means:
 - Compromising one connector does not compromise others
@@ -67,7 +67,7 @@ The promise of AI business intelligence is that you can ask any question about y
 
 Read-only access means:
 - Verified answers from live data
-- Zero risk of data modification
+- Retrieval operations do not modify their source records
 - Complete audit trail of every query
 - Per-source security boundaries
 
@@ -75,7 +75,7 @@ This is not a feature. It is the foundation of trust between AI and business dat
 
 ## What to Look For
 
-When evaluating AI data access platforms, verify that every connector uses read-only OAuth. Ask whether the platform stores your data between queries. Check whether you can see audit logs of what was accessed.
+When evaluating AI data access platforms, inspect provider scopes and tool-level safety metadata separately. Confirm that retrieval operations are marked read-only, identify any write-capable management or control-plane operations, ask what the platform retains, and check whether access is auditable.
 
 If a platform cannot answer these questions clearly, it does not have the security boundary your business data requires.
 

--- a/hermes/compare/corpusiq-vs-viktor.md
+++ b/hermes/compare/corpusiq-vs-viktor.md
@@ -25,7 +25,7 @@ CorpusIQ works everywhere. Connect your data once. Ask questions in ChatGPT, Cla
 ### Integrations: Breadth vs Trust
 Viktor claims 3,200+ managed connectors. Impressive scale. But managed connectors mean Viktor's team handles the integration — you hand over credentials and trust their pipeline.
 
-CorpusIQ takes the opposite approach. Forty deep native connectors. Read-only OAuth on every connection. You authorize access to Shopify, Stripe, QuickBooks, GA4, and Meta Ads. OAuth credentials are encrypted while the connection is active. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may persist for up to 30 days. Every answer cites its source record.
+CorpusIQ takes the opposite approach. Forty deep native connectors with source-specific authorization and operation-level safety metadata. You authorize access to Shopify, Stripe, QuickBooks, GA4, and Meta Ads. OAuth credentials are encrypted while the connection is active. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may persist for up to 30 days. Every answer cites its source record.
 
 ### The Data Question
 Ask Viktor to pull revenue numbers and it will execute the query. What query did it run? Which system did it hit? Did it cross-check Stripe against QuickBooks to catch the timing discrepancy? You do not know. The AI employee did it.

--- a/hermes/guides/corpusiq-claude-code.md
+++ b/hermes/guides/corpusiq-claude-code.md
@@ -40,7 +40,7 @@ Before Claude Code can answer business questions, connect your tools once:
 
 1. Go to [corpusiq.io/dashboard](https://corpusiq.io)
 2. Connect Shopify, Stripe, QuickBooks, GA4, Meta Ads — or any of the 40+ supported tools
-3. Each connection uses read-only OAuth with no write access; direct MCP does not retain raw customer files or full connector response payloads
+3. Each connection uses read-only external-source retrieval with no write access; direct MCP does not retain raw customer files or full connector response payloads
 
 ## Ask Business Questions
 
@@ -86,7 +86,7 @@ With CorpusIQ as the MCP server, every AI you use — Claude Code, ChatGPT, Perp
 
 Shopify. Stripe. QuickBooks. Google Analytics 4. Meta Ads. HubSpot. Klaviyo. Gmail. Google Drive. Dropbox. YouTube. Google Ads. eBay. Microsoft OneDrive. Outlook. And 25 more.
 
-Read-only OAuth on every connection. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may be retained for up to 30 days. Every answer cites its exact source.
+External-source retrieval tools are marked read-only; write-capable management/control-plane tools are separate. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may be retained for up to 30 days. Every answer cites its exact source.
 
 ## Get Started
 

--- a/hermes/mcp-ecosystem.md
+++ b/hermes/mcp-ecosystem.md
@@ -40,7 +40,7 @@ CorpusIQ is an AI intelligence layer connecting 40+ business tools to every AI a
 CorpusIQ is an operational intelligence layer. It sits between your business tools and every AI you use, giving you the same verified answer in ChatGPT, Claude, Perplexity, or Slack.
 
 - 40+ connectors: Shopify, Stripe, QuickBooks, GA4, Meta Ads, HubSpot, Klaviyo, Gmail, and more
-- Read-only OAuth on every connection
+- Read-only external-source retrieval with separately annotated management/control-plane writes
 - Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may be retained for up to 30 days
 - Every answer cites its exact source record
 - Same number in every AI, every time

--- a/hermes/mcp/servers/external/alison-ai-mcp/index.md
+++ b/hermes/mcp/servers/external/alison-ai-mcp/index.md
@@ -83,7 +83,7 @@ The client's first call returns `401` with a `WWW-Authenticate` header pointing 
 
 ## Integration with CorpusIQ
 
-Alison AI and CorpusIQ answer the two halves of the same question. CorpusIQ connectors — Meta Ads, Google Ads, LinkedIn Ads — pull cross-channel spend and revenue into one view with CorpusIQ's read-only OAuth model. Evo's MCP adds the creative layer those connectors don't carry: which tags, hooks, and formats are moving the numbers, plus SensorTower/Pathmatics competition metrics.
+Alison AI and CorpusIQ answer the two halves of the same question. CorpusIQ connectors — Meta Ads, Google Ads, LinkedIn Ads — pull cross-channel spend and revenue into one view with CorpusIQ's read-only external-source retrieval model. Evo's MCP adds the creative layer those connectors don't carry: which tags, hooks, and formats are moving the numbers, plus SensorTower/Pathmatics competition metrics.
 
 The composed workflow: CorpusIQ resolves "what did we spend and what did it return across Meta, Google, and LinkedIn," while the Evo MCP inside the same agent session resolves "which creatives drove it, which tags repeat across winners, and what competitors are running." Both surfaces are read-only and grant-scoped, so a growth analyst can be given both without handing over campaign edit rights or spend capability.
 

--- a/hermes/mcp/servers/external/devopness-mcp/index.md
+++ b/hermes/mcp/servers/external/devopness-mcp/index.md
@@ -123,7 +123,7 @@ Devopness uses a **credential firewall** architecture:
 3. Devopness API executes against your cloud using server-side credentials
 4. AI agent receives only results and status — never sees or touches credentials
 
-This is complementary to CorpusIQ's read-only OAuth model — CorpusIQ reads business data, Devopness executes infrastructure actions.
+This is complementary to CorpusIQ's read-only external-source retrieval model — CorpusIQ reads business data, Devopness executes infrastructure actions.
 
 ## Pitfalls
 

--- a/hermes/mcp/servers/external/easydocforms-mcp/index.md
+++ b/hermes/mcp/servers/external/easydocforms-mcp/index.md
@@ -71,7 +71,7 @@ Or point any MCP client at the published Docker config. Source: `github.com/easy
 
 easydocforms pairs naturally with CorpusIQ's document-intelligence and CRM connectors. A composed workflow: the agent retrieves the completed intake PDF, CorpusIQ's document connectors structure it into fields, and the HubSpot or CRM connector records the patient record and follow-up task — while the raw PHI stays in the form platform's storage, not in the agent transcript.
 
-The philosophy matches CorpusIQ's own read-only OAuth model: the agent orchestrates, the platform holds the sensitive data, and the operator stays in control of every system of record.
+The philosophy matches CorpusIQ's own read-only external-source retrieval model: the agent orchestrates, the platform holds the sensitive data, and the operator stays in control of every system of record.
 
 ## Limitations
 

--- a/hermes/mcp/servers/external/glc-promptguard-mcp/index.md
+++ b/hermes/mcp/servers/external/glc-promptguard-mcp/index.md
@@ -70,7 +70,7 @@ Self-register as an agent at `mcp.glc-rag.hu/guide/agent` with `account_type=age
 
 ## Integration with CorpusIQ
 
-PromptGuard is the guard layer for the CorpusIQ data plane. A composed workflow: an operator's agent grounds answers on CorpusIQ connector data (QuickBooks, HubSpot, Stripe), and PromptGuard screens both the user's prompt and any RAG chunks from external documents before the model sees them. CorpusIQ's read-only OAuth model already limits what data can be exfiltrated; PromptGuard limits what a malicious prompt can make the model do with the data it does see.
+PromptGuard is the guard layer for the CorpusIQ data plane. A composed workflow: an operator's agent grounds answers on CorpusIQ connector data (QuickBooks, HubSpot, Stripe), and PromptGuard screens both the user's prompt and any RAG chunks from external documents before the model sees them. CorpusIQ's read-only external-source retrieval model already limits what data can be exfiltrated; PromptGuard limits what a malicious prompt can make the model do with the data it does see.
 
 For agent builders offering CorpusIQ-powered assistants to their own users, the pair is the standard sandwich: scoped data access underneath, injection gate on top.
 

--- a/hermes/mcp/servers/external/index.md
+++ b/hermes/mcp/servers/external/index.md
@@ -842,7 +842,7 @@ Also discovered but not yet with full guides: MemeBoat MCP (meme generation), Pr
 
 ## Data Firewall Suite (PortEden)
 
-The **PortEden Secure*** family puts a data firewall between AI agents and your Google/Microsoft accounts. Every action is permission-gated, content-redacted, and audit-logged. One-click revoke. Complementary to CorpusIQ's read-only OAuth model.
+The **PortEden Secure*** family puts a data firewall between AI agents and your Google/Microsoft accounts. Every action is permission-gated, content-redacted, and audit-logged. One-click revoke. Complementary to CorpusIQ's read-only external-source retrieval model.
 
 ### Secure Calendar (Google Calendar & Outlook)
 Search schedule, check availability, create/reschedule/cancel events, RSVP. AI held to permissions you grant. Every change logged.

--- a/hermes/seo/ai-connectors-for-business.md
+++ b/hermes/seo/ai-connectors-for-business.md
@@ -16,7 +16,7 @@ AI connectors solve this. They create a read-only bridge between your business t
 
 ## What AI Connectors Do
 
-An AI connector authenticates to one business tool. Shopify. QuickBooks. Stripe. HubSpot. GA4. Using read-only OAuth. The AI can query data. It cannot modify anything.
+An AI connector authenticates to one business tool. Shopify. QuickBooks. Stripe. HubSpot. GA4. Using read-only external-source retrieval. The AI can query data. It cannot modify anything.
 
 When you ask ChatGPT "what was revenue last month," the connectors query your actual tools:
 - Shopify connector returns order data
@@ -55,7 +55,7 @@ Ask "what is our cash runway" and the system queries QuickBooks (current balance
 
 ## Security and Privacy
 
-Every connector uses read-only OAuth. The AI can see your data but never change it. No orders can be modified. No financials can be edited. No customer records can be altered.
+External-source retrieval tools are marked read-only and do not write records back to the connected source. Write-capable connector-management and CorpusIQ control-plane tools are separately named and safety-annotated.
 
 Each connector authenticates independently. Shopify has its own token. QuickBooks has its own. Stripe has its own. No shared credentials. No master key.
 

--- a/hermes/seo/ai-data-consistency.md
+++ b/hermes/seo/ai-data-consistency.md
@@ -38,7 +38,7 @@ A better AI model will still not have access to your Stripe account. Or your Sho
 
 The fix is the connection layer between your data and your AI.
 
-When your tools are connected once with read-only OAuth, every AI you use pulls from the same live data. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may be retained for up to 30 days.
+When your tools are connected once with read-only external-source retrieval, every AI you use pulls from the same live data. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may be retained for up to 30 days.
 
 The AI becomes a window into your actual numbers, not a guess generator.
 

--- a/hermes/seo/business-data-for-chatgpt.md
+++ b/hermes/seo/business-data-for-chatgpt.md
@@ -39,7 +39,7 @@ ChatGPT can answer general versions of these questions. It cannot answer them fo
 The approach is not to move your data into ChatGPT. ChatGPT is not a database and should not become one. The approach is to create a read-only bridge between ChatGPT and your business tools.
 
 Each tool connects independently:
-- Shopify via read-only OAuth for order and product data
+- Shopify via read-only external-source retrieval for order and product data
 - QuickBooks via Intuit API for financial data
 - Stripe via restricted API key for payment data
 - GA4 via Google Analytics API for traffic data

--- a/hermes/seo/connect-business-tools-to-ai.md
+++ b/hermes/seo/connect-business-tools-to-ai.md
@@ -1,6 +1,6 @@
 ---
 title: Connect Your Business Tools to AI — 40+ Read-Only Connectors
-description: Connect Shopify, Stripe, QuickBooks, GA4, and Meta Ads to ChatGPT, Claude, Perplexity, and Slack with read-only OAuth and source-cited answers.
+description: Connect Shopify, Stripe, QuickBooks, GA4, and Meta Ads to ChatGPT, Claude, Perplexity, and Slack with read-only external-source retrieval and source-cited answers.
 canonical: "https://www.corpusiq.io/docs/hermes/seo/connect-business-tools-to-ai/"
 robots: "index,follow"
 last_updated: "2026-08-12"

--- a/hermes/seo/connect-quickbooks-to-ai.md
+++ b/hermes/seo/connect-quickbooks-to-ai.md
@@ -32,7 +32,7 @@ With a direct connection:
 
 ## How the Connection Works
 
-The connection uses read-only OAuth through Intuit's API. You authorize once through your QuickBooks login. The AI gains permission to query your company data. It cannot create transactions. Cannot modify accounts. Cannot send invoices or process payments.
+The connection uses read-only external-source retrieval through Intuit's API. You authorize once through your QuickBooks login. The AI gains permission to query your company data. It cannot create transactions. Cannot modify accounts. Cannot send invoices or process payments.
 
 Every query is:
 1. Authenticated independently

--- a/hermes/seo/connect-shopify-to-chatgpt.md
+++ b/hermes/seo/connect-shopify-to-chatgpt.md
@@ -34,7 +34,7 @@ Connect Shopify directly to AI and the workflow becomes: ask your question. Get 
 
 ## How It Works
 
-The connection uses read-only OAuth. You authorize once. Shopify grants access to view your data. The AI can query orders, products, customers, and analytics. It cannot modify anything. No orders can be changed. No products can be deleted. No customer data can be exported.
+The connection uses read-only external-source retrieval. You authorize once. Shopify grants access to view your data. The AI can query orders, products, customers, and analytics. It cannot modify anything. No orders can be changed. No products can be deleted. No customer data can be exported.
 
 When you ask "what was revenue last month," the system:
 1. Queries Shopify for order data in the date range
@@ -56,7 +56,7 @@ When you ask "what was revenue last month," the system:
 
 A platform that:
 - Has a pre-built Shopify connector (not something you build yourself)
-- Uses read-only OAuth (the AI can see data but never change it)
+- Uses read-only external-source retrieval (the AI can see data but never change it)
 - Supports cross-tool queries (Shopify + Stripe + QuickBooks in one question)
 - Provides source citations (every number traces back to Shopify)
 - Works across multiple AIs (ChatGPT, Claude, Perplexity all get the same answers)

--- a/hermes/seo/consistent-ai-answers.md
+++ b/hermes/seo/consistent-ai-answers.md
@@ -34,7 +34,7 @@ By the time you have an answer, you could have just done the math yourself.
 
 Connect your tools once. Let every AI inherit the connections.
 
-CorpusIQ sits between your business tools and every AI you use. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may be retained for up to 30 days. It does not write to your systems. It connects with read-only OAuth to Shopify, Stripe, QuickBooks, GA4, Meta Ads, HubSpot, and thirty-five more.
+CorpusIQ sits between your business tools and every AI you use. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may be retained for up to 30 days. It does not write to your systems. It connects with read-only external-source retrieval to Shopify, Stripe, QuickBooks, GA4, Meta Ads, HubSpot, and thirty-five more.
 
 Ask ChatGPT a question. It routes to your live data. It returns an answer with the exact source record cited — order number, transaction ID, campaign name. You can verify it instead of trusting it blind.
 
@@ -48,6 +48,6 @@ The AI changes. The answer does not.
 
 Stop being the bridge between your data and your AI. Connect once. Ask any AI. Get the same verified answer every time.
 
-Live retrieval with scoped retention. Read-only OAuth on every connection. Five-minute setup.
+Live retrieval with scoped retention. Operation-level safety annotations. Five-minute setup.
 
 [Connect your tools](https://corpusiq.io)

--- a/hermes/seo/manual-reporting-time-waste.md
+++ b/hermes/seo/manual-reporting-time-waste.md
@@ -40,7 +40,7 @@ You already use AI. ChatGPT, Claude, Perplexity. You ask them questions all day.
 
 But they cannot see your actual business data. They are brilliant but blind.
 
-Connect your tools once with read-only OAuth. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may be retained for up to 30 days. Every AI you use inherits the connections.
+Connect your tools once with read-only external-source retrieval. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may be retained for up to 30 days. Every AI you use inherits the connections.
 
 Ask ChatGPT about weekly revenue. It pulls from Stripe, cross-checks against Shopify, flags discrepancies against QuickBooks, and returns a source-cited answer. Same number in Claude. Same number in Perplexity.
 

--- a/hermes/setup/corpusiq-mcp.md
+++ b/hermes/setup/corpusiq-mcp.md
@@ -109,9 +109,9 @@ Now your Hermes Agent can answer business questions from live data:
 
 CorpusIQ exposes 40+ connectors as MCP tools. Hermes auto-discovers them. No code. No SDK. Just connect and ask.
 
-## Read-only guarantee
+## Operation-level safety
 
-All CorpusIQ connections are read-only by design. OAuth scopes only request read access. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may persist for up to 30 days.
+External-source retrieval tools are marked read-only. Write-capable connector-management and CorpusIQ control-plane tools are separately named and annotated; provider scopes vary by connector. Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may persist for up to 30 days.
 
 ## Token refresh for crons
 

--- a/how-it-works/connectors-explained.md
+++ b/how-it-works/connectors-explained.md
@@ -84,10 +84,7 @@ don't have to know that — the skills engine handles it. See
 ## When you want it off
 
 Disconnect any connector from the CorpusIQ status panel. The token is
-deleted from CorpusIQ's storage. The vendor's side will also show the
-app as removed once the token expires (most fire-and-forget tokens are
-gone within an hour; refresh tokens are wiped immediately on
-disconnect).
+removed from CorpusIQ's active connection state, which requires reauthorization before reuse. Provider-side authorization and token expiration remain governed by the provider; manage them in the provider's controls.
 
 You can reconnect at any time. There is no penalty for switching off and
 back on.

--- a/how-it-works/mcp-architecture.md
+++ b/how-it-works/mcp-architecture.md
@@ -80,9 +80,7 @@ Each of CorpusIQ's 31 connectors is an isolated module that:
 3. Translates MCP tool calls into vendor API calls, handles pagination,
    and normalizes the response into consistent JSON.
 
-Connectors are **read-only by design**. CorpusIQ requests read scopes
-only during OAuth and has no write paths in any connector. This is not
-a configuration option — it is an architectural constraint.
+External-source retrieval tools are marked read-only. Write-capable connector and CorpusIQ control-plane tools are separately named and carry behavior-matched safety annotations. Provider scopes vary by connector and documented operation.
 
 When you call a tool like `get_orders`, the flow is:
 
@@ -148,8 +146,7 @@ persist across sessions.
 
 ## Security model
 
-- **Read-only everywhere.** No connector has write access. This is
-  enforced at the connector layer, not just by policy.
+- **Operation-level permissions.** Retrieval tools are marked read-only; write-capable connector and CorpusIQ control-plane tools are separately named and annotated.
 - **Per-user token isolation.** OAuth tokens are stored encrypted and
   scoped per user account. One user's token cannot be used by another.
 - **Scoped direct-MCP retention.** Each tool call fetches live vendor data.

--- a/how-it-works/metric-specs.md
+++ b/how-it-works/metric-specs.md
@@ -436,10 +436,10 @@ reaches your specs.
 
 The provenance footer reports the moment the resolve ran (implicit in
 its `computed_at` field on the underlying `MetricSpecResult`) and tells
-you how many rows came from each connector. There is no "last cache
-update" because there is no cache. If you want to know how stale the
-underlying vendor data is, ask the AI to surface the most recent row
-timestamp alongside the value — that's a one-line addition to the
+you how many rows came from each connector. Metric resolution requests
+current source data; freshness follows each provider and CorpusIQ cache
+behavior. To assess vendor freshness, ask the AI to surface the most
+recent row timestamp alongside the value — that's a one-line addition to the
 question.
 
 **Can I version a spec?**

--- a/how-it-works/privacy-and-security.md
+++ b/how-it-works/privacy-and-security.md
@@ -48,10 +48,7 @@ CorpusIQ uses the refresh-token flow (where the vendor provides one) so
 you don't have to re-authenticate constantly. The refresh token is also
 encrypted at rest.
 
-**Honors disconnect immediately.** When you disconnect a connector,
-CorpusIQ deletes the stored token. Future requests to that connector
-fail until you reconnect. Most vendors also let you revoke the
-authorization from their own admin panel.
+**Disconnects fail closed.** When a disconnect tombstone commits, CorpusIQ stops selecting the stored grant and requires reauthorization before reuse. Credential cleanup is attempted after the tombstone; provider authorization remains provider-governed and can be managed from the provider admin panel.
 
 ## Where the data is
 
@@ -71,8 +68,7 @@ ChatGPT carries that identity so CorpusIQ knows it's you.
 
 **Layer 2 — CorpusIQ's link to each vendor.** Separately, each connector
 holds its own OAuth token scoped to your CorpusIQ identity. When you
-ask a question, CorpusIQ looks up the right vendor token, makes the
-read-only call, and returns the result.
+ask a question, CorpusIQ looks up the right vendor token, invokes the documented operation and returns the result.
 
 If Layer 1 fails, you can't use CorpusIQ at all. If Layer 2 fails for a
 specific connector (token expired, vendor revoked, scopes changed),
@@ -88,13 +84,11 @@ assistant only sees:
 
 The assistant does not see your raw tokens. It does not have direct
 network access to Shopify or QuickBooks. Every external call goes
-through CorpusIQ's server, which enforces the read-only contract.
+through CorpusIQ's server, which enforces operation-level routing and safety annotations.
 
 ## What to do if something feels wrong
 
-- **Disconnect first, ask questions later.** Disconnect from the
-  CorpusIQ status panel and the token is gone. You can reconnect any
-  time.
+- **Disconnect first, ask questions later.** Disconnecting in CorpusIQ commits inactive connection state and requires reauthorization before reuse. Provider authorization remains provider-governed.
 - **Revoke from the vendor side too.** Google, Microsoft, Shopify, and
   most other vendors have a "Connected apps" page where you can revoke
   CorpusIQ's access directly. That's belt and suspenders.
@@ -103,8 +97,7 @@ through CorpusIQ's server, which enforces the read-only contract.
 ## Disconnect anytime
 
 This is the bottom line: CorpusIQ only works for as long as you let it.
-Pull the plug on any connector at any time and it stops reading that
-tool immediately. Optional indexed-search embeddings and minimal metadata
+After a disconnect tombstone commits, CorpusIQ stops selecting that connector grant and requires reauthorization before reuse. Optional indexed-search embeddings and minimal metadata
 are removed on connector revocation or account deletion; operational logs
 expire within 30 days, and deletion/compliance receipts may remain for up
 to 24 months.

--- a/how-it-works/reading-files-and-pdfs.md
+++ b/how-it-works/reading-files-and-pdfs.md
@@ -80,6 +80,5 @@ sales or marketing data:
 - "What payment terms are in the latest invoice in Dropbox?"
 - "Find the renewal date in the lease PDF on OneDrive."
 
-The answer comes back with the source file cited, read-only, pulled live
-when you ask — nothing about your files is moved or stored. See
+The answer comes back with the source file cited through a read-only retrieval tool. Direct MCP does not retain raw customer files or full connector response payloads; operational logs and optional indexed search follow their published lifecycles. See
 [privacy-and-security.md](privacy-and-security.md) for what that means.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -125,7 +125,7 @@ CorpusIQ provides read-only external-source retrieval between authorized SaaS ap
 
 - **40+ native connectors**  --  Gmail, Google Drive, Slack, HubSpot, Shopify, QuickBooks, PostgreSQL, and more
 - **MCP-native**  --  Designed for AI assistants that speak the Model Context Protocol
-- **Read-only by design**  --  OAuth scopes are restricted to read access; no write permissions are ever requested
+- **Operation-level permissions**  --  External-source retrieval tools are marked read-only; write-capable and CorpusIQ control-plane tools are separately named and annotated
 - **Scoped data handling**  --  Direct MCP uses live retrieval; optional indexed-search features use embeddings and minimal metadata
 - **SOC 2 aligned & CASA Tier 2 certified**  --  formal SOC 2 certification is not claimed; CASA was assessed by DEKRA
 
@@ -320,7 +320,7 @@ A: Any MCP-compatible client. Claude, ChatGPT, Perplexity, local Ollama models, 
 A: No. CorpusIQ is a standalone MCP server. You can use it with a local LLM, any API provider, or any MCP-compatible tool. No vendor lock.
 
 **Q: What data operations can my AI agent perform?**  
-A: Your agent can query ~500 tools across 34 business connectors  --  Stripe revenue, QuickBooks P&L, HubSpot deals, Shopify orders, Meta Ads campaigns, GA4 analytics, PostgreSQL/MSSQL/MongoDB queries  --  all read-only.
+A: Your agent can use the reviewer-visible CorpusIQ tool catalog across business connectors. External-source retrieval tools are marked read-only; write-capable connector-management and CorpusIQ control-plane tools are separately named and annotated.
 
 ---
 
@@ -373,7 +373,7 @@ The CorpusIQ AI chat provides natural language access to your connected business
 ## Search and Retrieval Capabilities
 
 - Natural language search across all connected sources
-- Real-time data queries (no cached or stale data)
+- Live source queries; provider and transport caching behavior may vary
 - Cross-source correlation (e.g., Stripe revenue vs Shopify orders)
 - Date range filtering
 - Aggregation and summarization
@@ -606,7 +606,7 @@ The CorpusIQ MCP platform is purpose-built for AI-powered business intelligence.
 
 2. **MCP-native architecture.** Built on the Model Context Protocol, an open standard for AI-to-tool communication. Any MCP-compatible AI (Claude, ChatGPT, and others) can use CorpusIQ connectors.
 
-3. **Read-only security model.** OAuth 2.0 with read-only scope across all integrations. AI can query data but can never modify systems of record.
+3. **Operation-level security model.** External-source retrieval tools are marked read-only. Write-capable connector-management and CorpusIQ control-plane tools are separately named and safety-annotated.
 
 4. **Cross-source query engine.** Ask one question that spans five tools. "How did our Facebook ad spend correlate with Shopify revenue and Google Analytics traffic last month?"  --  answered in a single response.
 
@@ -1390,7 +1390,7 @@ CorpusIQ connects AI to your financial systems through the Model Context Protoco
 - **Stripe integration:** Charges, subscriptions, MRR, refunds, disputes, payouts, balance  --  your payment data becomes conversational.
 - **NetSuite integration:** Enterprise ERP data  --  financials, inventory, orders, procurement  --  accessible through AI.
 - **Cross-source correlation:** Compare QuickBooks to Stripe, NetSuite to Salesforce, Shopify to your accounting system  --  all in one conversation.
-- **Read-only security:** OAuth 2.0 with read-only scope. AI can analyze financial data but can never create, modify, or delete transactions.
+- **Operation-level safety:** Retrieval tools are marked read-only; write-capable connector and control-plane tools are separately named and annotated.
 
 ## Example Financial Analysis Queries
 
@@ -2069,7 +2069,7 @@ Status meetings can be shorter and more productive when AI has already gathered 
 A: Monday.com is supported natively. Jira, Asana, and Linear can be accessed via database connectors or API. Direct connectors for additional PM tools are in development.
 
 **Q: Can AI create or update tasks?**
-A: No. All integrations are read-only. AI analyzes and reports on project data but cannot modify it.
+A: The project-management retrieval tools documented here analyze and report on project data; they do not create or update source tasks. Separately named CorpusIQ control-plane tools can update user-declared CorpusIQ state.
 
 **Q: How does AI handle complex project dependencies?**
 A: Claude can analyze task relationships and dependencies when they're represented in your project management tool's data model and identify at-risk dependency chains.
@@ -2144,7 +2144,7 @@ The CorpusIQ platform provides the connective tissue that makes unified RevOps p
 - **Billing connectors:** Stripe, QuickBooks, NetSuite.
 - **Analytics connectors:** GA4, PostHog, database connectors (PostgreSQL, MSSQL, MongoDB).
 - **Unified querying:** Ask one question that spans five tools.
-- **Read-only across all systems:** Zero risk of modifying production data.
+- **Explicit tool boundaries:** Retrieval tools are marked read-only; write-capable management/control-plane tools are separately named and annotated.
 
 ## Example RevOps Queries
 
@@ -2271,7 +2271,7 @@ CorpusIQ connects AI to your CRM and related systems:
 - **HubSpot integration:** Contacts, companies, deals, pipeline stages, and activity history.
 - **Close CRM integration:** Leads, opportunities, activities, and sales rep performance.
 - **Cross-source correlation:** CRM + ERP + billing + marketing  --  unified revenue intelligence.
-- **Read-only security:** OAuth 2.0 with read-only scope. AI can analyze CRM data but can never modify records.
+- **Operation-level safety:** Retrieval tools are marked read-only; write-capable connector and control-plane tools are separately named and annotated.
 
 ## Example Sales Reporting Queries
 
@@ -2329,7 +2329,7 @@ A: Yes. CorpusIQ queries the standard REST API, so custom objects and fields acc
 A: Real-time. Every query triggers a live API call to your CRM.
 
 **Q: Can AI create opportunities or update CRM records?**
-A: No. All integrations are read-only.
+A: The CRM retrieval tools documented here do not create opportunities or update source CRM records. Separately named CorpusIQ control-plane tools can update user-declared CorpusIQ state.
 
 ## Internal Links
 
@@ -2419,7 +2419,7 @@ Your backend forwards authenticated user requests to CorpusIQ. The API token nev
 
 ### Token Revocation
 
-Tokens can be revoked from the Dashboard (**Settings → API → Revoke All Tokens**). The service commits an inactive state before credential cleanup and surfaces cleanup failures for retry. If a token is compromised, revoke it through CorpusIQ and the provider, then generate a new one.
+The Dashboard can clear CorpusIQ MCP session state so a fresh token is required at the next login. This does not revoke authorization held by a connected provider; manage provider-side authorization in the provider's controls.
 
 ## Header Reference
 
@@ -2427,7 +2427,6 @@ Tokens can be revoked from the Dashboard (**Settings → API → Revoke All Toke
 |--------|----------|-------------|
 | `Authorization` | Yes | `Bearer <token>` |
 | `Content-Type` | Yes (POST) | Must be `application/json` |
-| `Idempotency-Key` | Optional | Unique key for idempotent `/query` requests |
 
 ## Testing Authentication
 
@@ -2496,7 +2495,6 @@ Search across all connected data sources with a natural-language query.
 POST /v1/query
 Content-Type: application/json
 Authorization: Bearer <token>
-Idempotency-Key: <unique-key>  (optional)
 ```
 
 | Field | Type | Required | Description |
@@ -2547,14 +2545,6 @@ Idempotency-Key: <unique-key>  (optional)
 }
 ```
 
-### Idempotency
-
-Pass an `Idempotency-Key` header to safely retry `/query` requests without creating duplicate query records. The key must be unique per request. Subsequent requests with the same key within 24 hours return the cached response.
-
-```http
-Idempotency-Key: req_2026-06-16_sales_report
-```
-
 ### Code Examples
 
 **cURL**
@@ -2563,7 +2553,6 @@ Idempotency-Key: req_2026-06-16_sales_report
 curl -X POST https://mcp2.corpusiq.io/mcp \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
-  -H "Idempotency-Key: $(uuidgen)" \
   -d '{
     "query": "Show me recent HubSpot deals over $10,000",
     "connectors": ["hubspot"],
@@ -2579,7 +2568,6 @@ const response = await fetch("https://mcp2.corpusiq.io/mcp", {
   headers: {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
-    "Idempotency-Key": crypto.randomUUID(),
   },
   body: JSON.stringify({
     query: "Show me recent HubSpot deals over $10,000",
@@ -2596,14 +2584,12 @@ console.log(data.results);
 
 ```python
 import requests
-import uuid
 
 response = requests.post(
     "https://mcp2.corpusiq.io/mcp",
     headers={
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
-        "Idempotency-Key": str(uuid.uuid4()),
     },
     json={
         "query": "Show me recent HubSpot deals over $10,000",
@@ -2776,7 +2762,7 @@ All CorpusIQ API errors follow a consistent JSON structure with a machine-readab
 | **401** | `unauthorized` | The Bearer token is missing, invalid, or expired. Obtain a new token. An `X-Token-Expired: true` header accompanies expired tokens. |
 | **403** | `forbidden` | The authenticated user does not have permission to access the requested resource or connector. Verify connector OAuth scopes. |
 | **404** | `not_found` | The requested resource (query ID, connector, or endpoint) does not exist. Check the URL and resource identifiers. |
-| **409** | `conflict` | The request conflicts with the current state. Common for duplicate `Idempotency-Key` submissions with different request bodies. |
+| **409** | `conflict` | The request conflicts with the current resource state. Inspect the response details before retrying. |
 | **413** | `payload_too_large` | The request body exceeds the maximum allowed size of 1 MB. Reduce `max_results` or split the query. |
 | **429** | `rate_limited` | The rate limit for the endpoint has been exceeded. A `retry_after_seconds` field indicates when to retry. See [Rate Limits](/docs/api/rate-limits). |
 | **500** | `server_error` | An unexpected internal error occurred on the CorpusIQ side. Retry with exponential backoff. If errors persist, contact api@corpusiq.io. |
@@ -2831,9 +2817,9 @@ for attempt in range(max_retries):
         time.sleep(wait)
 ```
 
-## Idempotency and 409 Conflicts
+## 409 Conflicts
 
-A `409 Conflict` with `Idempotency-Key` means the same key was used with a different request body. Generate a new key for each unique request. If the request body is identical, the API returns the cached response with a `200` status.
+A `409 Conflict` means the request conflicts with current resource state. Inspect the response details and do not assume a retry is safe.
 
 ## Frequently Asked Questions
 
@@ -2974,14 +2960,6 @@ paths:
         Execute a natural-language query across all or specified connected business
         tools. Returns semantically ranked, cited results from each connector.
       operationId: "searchQuery"
-      parameters:
-        - name: "Idempotency-Key"
-          in: "header"
-          required: false
-          schema:
-            type: "string"
-            format: "uuid"
-          description: "Unique key for idempotent requests. Prevents duplicate query records."
       requestBody:
         required: true
         content:
@@ -3282,7 +3260,7 @@ All endpoint paths are relative to this base. The API version (`v1`) is part of 
 
 The primary endpoint for querying connected business tools. Accepts a natural-language question and an optional list of connector IDs to scope the search. CorpusIQ translates the query into read-only API calls, retrieves matching records, ranks them semantically, and returns cited results.
 
-Each `/query` request generates a unique `query_id` that can be used for idempotency and debugging. The `Idempotency-Key` header protects against duplicate submissions.
+Each `/query` request generates a unique `query_id` for tracing and debugging.
 
 ### POST /deep_search
 
@@ -3324,7 +3302,7 @@ A: The API offers POST /query for connected-source search and POST /deep_search 
 A: All successful responses return HTTP 200 with a JSON body. Errors follow a consistent format with 'type' and 'message' fields. See the errors reference for complete error codes.
 
 **Q: Is the CorpusIQ API read-only?**  
-A: Yes. All API endpoints are read-only. The platform never writes, modifies, or deletes your business data. This is enforced at the protocol, connector, and OAuth scope levels.
+A: External-source retrieval endpoints are read-only. Connector-management and CorpusIQ control-plane endpoints can change CorpusIQ-owned state and are documented separately.
 
 **Q: How fast are API query responses?**  
 A: Most queries return results in 1–5 seconds. Cross-source queries spanning multiple business tools may take slightly longer depending on the number of API calls required.
@@ -3419,9 +3397,9 @@ if remaining < 5:
     time.sleep(10)  # Let the rate limit window catch up
 ```
 
-### Use Idempotency Keys
+### Retry Explicitly
 
-For `/query`, use `Idempotency-Key` headers to safely retry without consuming additional rate limit quota. Duplicate requests with the same key within 24 hours return a cached response and do not count against your limit.
+Retry only after an explicit transient error, and follow the response status and retry guidance.
 
 ### Batch Questions
 
@@ -3648,7 +3626,7 @@ Individual adapters for each of the 36 supported business data sources. Each con
 
 ## Security Model
 
-- Read-only access to all connected data sources
+- Read-only external-source retrieval with separately annotated management/control-plane writes
 - OAuth 2.0 with refresh token rotation
 - Device flow prevents credential exposure
 - HTTPS/TLS for all connections
@@ -3707,15 +3685,15 @@ This real-time capability eliminates the decision latency that plagues tradition
 
 Consider a retail business monitoring Black Friday performance. With a data warehouse, they're looking at data that's hours old. With MCP, they can ask "what's selling fastest right now?" and get an answer drawn from live Shopify data. That timeliness translates to better decisions about inventory reallocation, promotional adjustments, and staffing.
 
-## 2. Security by Design: Read-Only Access
+## 2. Security by Design: Explicit Tool Boundaries
 
-MCP servers, as implemented by CorpusIQ, default to read-only access. This is not an accident  --  it's a deliberate architectural choice that eliminates the largest category of integration risk: unintended data modification.
+CorpusIQ separates external-source retrieval from write-capable connector-management and CorpusIQ control-plane operations. Tool names, schemas, and safety annotations make that boundary visible before invocation.
 
 Every other integration approach  --  direct API access, RPA bots, database connections  --  requires careful permission management to prevent write operations. A developer with a database connection string can potentially modify or delete records. An RPA bot with user credentials can perform any action the user can. Even a well-intentioned API integration can have bugs that modify production data.
 
-MCP's read-only default means even a misconfigured query or an erroneous AI suggestion cannot modify your data. The worst that can happen is an incorrect answer  --  not an incorrect database update. This property is particularly valuable for financial systems, CRM platforms, and other mission-critical data sources where data integrity is paramount.
+Retrieval tools marked read-only cannot execute write operations. Write-capable tools are separately named and limited to their declared actions. This reduces unintended-change risk for financial systems, CRM platforms, and other mission-critical sources without claiming that the whole product is read-only.
 
-For organizations that do need write capabilities, CorpusIQ supports scoped write operations with explicit opt-in at both the OAuth and server configuration levels. But the default is safety.
+AI clients can use the published safety annotations when deciding whether to request confirmation. The exact confirmation behavior remains governed by the selected client's interface and policy.
 
 ## 3. AI-Native Simplicity
 
@@ -4855,7 +4833,7 @@ The first public release of the CorpusIQ API, providing programmatic access to t
 
 ### New Endpoints
 
-- **`POST /v1/query`**  --  Search across all connected business tools with natural-language queries. Supports connector scoping via the `connectors` parameter and idempotent submissions via the `Idempotency-Key` header. Returns semantically ranked, cited results from each matching connector.
+- **`POST /v1/query`**  --  Search across all connected business tools with natural-language queries. Supports connector scoping via the `connectors` parameter and returns semantically ranked, cited results from each matching connector.
 
 - **`POST /v1/deep_search`**  --  Search the encrypted archive of previously executed queries and their results. Supports date-range filtering and returns similarity-scored matches.
 
@@ -4865,7 +4843,7 @@ The first public release of the CorpusIQ API, providing programmatic access to t
 - Bearer token authentication via `Authorization` header
 - 60-minute token expiry with server-side refresh detection
 - Token issuance through the CorpusIQ Dashboard and ChatGPT Actions
-- Immediate token revocation from the Dashboard
+- Dashboard disconnect commits inactive CorpusIQ connection state; provider-side authorization remains governed by the provider
 
 ### OpenAPI Specification
 
@@ -4882,7 +4860,7 @@ The first public release of the CorpusIQ API, providing programmatic access to t
 
 ### Security
 
-- Read-only OAuth scopes across all connectors
+- Operation-level safety annotations distinguish external-source retrieval from write-capable management/control-plane tools
 - Scoped data handling: direct MCP live retrieval plus optional indexed-search embeddings
 - TLS 1.3 for all API traffic
 - AES-256-GCM encryption at rest
@@ -4891,7 +4869,7 @@ The first public release of the CorpusIQ API, providing programmatic access to t
 ### Connectors
 
 - 40+ native connectors spanning email, calendar, file storage, analytics, CRM, ecommerce, marketing, financial, social media, and databases
-- Read-only OAuth for all cloud services
+- Provider scopes match each connector's documented operations
 - Direct database connectors for PostgreSQL, SQL Server, MySQL, Azure Cosmos DB, and MongoDB
 
 ### Documentation
@@ -5614,7 +5592,7 @@ Instead of navigating QuickBooks' report menus or exporting CSV files for analys
 
 CorpusIQ's MCP platform acts as the secure middleware layer between ChatGPT and QuickBooks Online. Here's the workflow:
 
-1. **Connect Your QuickBooks Account**  --  Authenticate via OAuth 2.0 in under 60 seconds. CorpusIQ establishes a read-only connection to your QuickBooks company file, ensuring your financial data can be queried but never modified by the AI.
+1. **Connect Your QuickBooks Account**  --  Authenticate via OAuth 2.0 in under 60 seconds. CorpusIQ exposes separately named QuickBooks retrieval tools that are marked read-only; write-capable tools, when present, are separately annotated.
 
 2. **ChatGPT Gains Financial Context**  --  Once connected, CorpusIQ exposes QuickBooks as a set of structured tools that ChatGPT can invoke. These include profit & loss reports, balance sheets, accounts receivable aging, invoice lookups, customer searches, and vendor lists.
 
@@ -5796,7 +5774,7 @@ A product manager asks: "Show me the first 30 days of sales for our three most r
 Yes. CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 
 ### Can ChatGPT modify my Shopify store?
-No. The CorpusIQ-Shopify connection is strictly read-only. ChatGPT can analyze your data and make recommendations, but it cannot create products, modify orders, change inventory, adjust prices, or alter any store settings. Your store remains fully under your control.
+The advertised Shopify retrieval tools are read-only and support analysis and recommendations without changing store records. Write-capable tools, when available, are separately named and annotated.
 
 ### What Shopify data can ChatGPT access?
 ChatGPT can access orders, products, customers, inventory levels, discount codes, refund data, and store analytics. It can query across all these data types and perform calculations  --  revenue analysis, customer segmentation, product performance, inventory forecasting  --  using your live data.
@@ -5918,7 +5896,7 @@ All 36 CorpusIQ connectors are available through the ChatGPT integration. See th
 ## Frequently Asked Questions
 
 **Q: How do I connect CorpusIQ to ChatGPT?**  
-A: Open ChatGPT, search for 'CorpusIQ', click Connect to authorize via OAuth, and link your CorpusIQ account. ChatGPT will have immediate read-only access to all your connected business data sources.
+A: Open ChatGPT, search for 'CorpusIQ', click Connect, and authorize your CorpusIQ account. External-source retrieval tools are marked read-only; write-capable and CorpusIQ control-plane tools are separately named and annotated.
 
 **Q: What can I ask ChatGPT with CorpusIQ connected?**  
 A: Ask about MRR, revenue trends, top customers, marketing ROAS, order volumes, P&L statements, pipeline value, and more. Example: 'What was our MRR last month?' or 'Compare this month's revenue to last month.'
@@ -6150,7 +6128,7 @@ The context window is how much information the AI can "hold in mind" at once. Cl
 CorpusIQ uses a read-only QuickBooks connection and encrypted transport. Data handling inside Claude follows the terms and settings of the Anthropic plan you choose; review Anthropic's current policy before sending sensitive financial data.
 
 ### Can Claude create QuickBooks journal entries?
-No. Like all CorpusIQ AI integrations, the QuickBooks connection is read-only. Claude can identify needed adjustments and draft journal entry recommendations, but a human must approve and enter them into QuickBooks. This separation of analysis from execution is a deliberate safety feature.
+The QuickBooks retrieval tools documented here are read-only and can identify adjustments or draft recommendations. Write-capable connector and CorpusIQ control-plane tools, when present, are separately named and annotated.
 
 ### Does Claude work with QuickBooks Desktop?
 Claude through CorpusIQ connects to QuickBooks Online via the QuickBooks API. QuickBooks Desktop is not directly supported, though enterprise customers can arrange for batch data imports. Contact our sales team for Desktop integration options.
@@ -6369,7 +6347,7 @@ CorpusIQ connects to your Asana account via OAuth 2.0. You authorize read-only a
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only OAuth scopes from Asana. ChatGPT can see projects, tasks, sections, assignees, and custom fields. It cannot create tasks, reassign work, change due dates, modify projects, or alter anything in your Asana workspace. The read-only guarantee is enforced at both the OAuth permission and MCP tool layers.
+Yes. CorpusIQ requests read-only external-source retrieval scopes from Asana. ChatGPT can see projects, tasks, sections, assignees, and custom fields. It cannot create tasks, reassign work, change due dates, modify projects, or alter anything in your Asana workspace. The read-only guarantee is enforced at both the OAuth permission and MCP tool layers.
 </details>
 
 <details>
@@ -6527,7 +6505,7 @@ CorpusIQ connects to your Gmail account via Google OAuth 2.0 with read-only scop
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only Gmail scopes: gmail.readonly. ChatGPT can search, list, and read emails. It cannot send emails, delete messages, modify labels, change settings, or perform any write operation in your Gmail account. The read-only guarantee is enforced by the Google OAuth scope  --  Gmail's readonly scope does not include any write capabilities.
+Yes. CorpusIQ requests read-only Gmail scopes: gmail.readonly. ChatGPT can search, list, and read emails. It cannot send emails, delete messages, modify labels, change settings, or perform any write operation in your Gmail account. The advertised Gmail retrieval tools are marked read-only. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>
@@ -6955,7 +6933,7 @@ CorpusIQ connects to HubSpot via OAuth 2.0 and exposes HubSpot's CRM objects as 
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only scopes from HubSpot. ChatGPT can see contacts, deals, and companies. It cannot create contacts, move deals between stages, modify company properties, or change anything in your CRM. The read-only guarantee is enforced at both the OAuth scope level and the MCP tool level.
+The advertised HubSpot retrieval tools are read-only and expose contacts, deals, and companies without modifying them. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>
@@ -7048,10 +7026,10 @@ Instead of building a pipeline report in HubSpot: "Show me all deals by stage wi
 
 ## Security: Read-Only by Design
 
-The HubSpot integration is read-only at every layer:
+The advertised HubSpot retrieval surface is read-only:
 
-- **OAuth Scopes:** Read-only access to contacts, companies, deals, and account metadata. No write, create, update, or delete permissions.
-- **MCP Tools:** Only query tools are exposed  --  contact search, deal listing, company retrieval. No tools exist to create, modify, or delete HubSpot records.
+- **Retrieval tools:** Contact search, deal listing, and company retrieval are marked read-only.
+- **Other operations:** Write-capable tools, when available, are separately named and annotated.
 - **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 - **Encryption:** All data in transit is encrypted via TLS 1.3 between HubSpot, CorpusIQ, and ChatGPT.
 
@@ -7150,9 +7128,9 @@ CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain
 
 ### Security
 
-- **Read-only OAuth 2.0.** Claude can query contacts, companies, and deals but cannot create, update, or delete CRM records.
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
-- **Instant disconnect.** Revoke access from HubSpot or CorpusIQ at any time.
+- **Operation-level safety.** HubSpot retrieval tools are marked read-only; write-capable tools, when present, are separately named and annotated.
+- **Scoped direct-MCP retention.** Direct MCP does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Disconnect behavior.** CorpusIQ disconnect requires reauthorization before reuse; provider authorization remains governed by HubSpot.
 
 ### Comparison: MCP vs. HubSpot API Direct
 
@@ -7405,7 +7383,7 @@ CorpusIQ connects to your Monday.com account via OAuth 2.0. You authorize read-o
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only OAuth scopes from Monday.com. ChatGPT can see boards, items, statuses, owners, and due dates. It cannot create items, update statuses, reassign tasks, or modify anything in your Monday.com account. The read-only guarantee is enforced at the OAuth scope level.
+Yes. CorpusIQ requests read-only external-source retrieval scopes from Monday.com. ChatGPT can see boards, items, statuses, owners, and due dates. It cannot create items, update statuses, reassign tasks, or modify anything in your Monday.com account. The advertised Monday.com retrieval tools are marked read-only; write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>
@@ -7530,19 +7508,6 @@ Direct API integration is appropriate for building custom Monday.com apps, autom
 5. **Explore.** Try "Show me my open tasks across all boards" or "What's due this week?"
 
 Setup takes under 5 minutes. No API keys to manage. No GraphQL to write.
-
-## Related Pages
-
-- [Connect Asana to ChatGPT](connect-asana-to-chatgpt.md)  --  alternative work management in ChatGPT
-- [Connect Jira to ChatGPT](connect-jira-to-chatgpt.md)  --  software development tracking in ChatGPT
-- [Connect Notion to ChatGPT](connect-notion-to-chatgpt.md)  --  documentation and wiki in ChatGPT
-- [Connect Slack to ChatGPT](connect-slack-to-chatgpt.md)  --  team communication in ChatGPT
-- [Connect HubSpot to ChatGPT](connect-hubspot-to-chatgpt.md)  --  CRM data in ChatGPT
-- [ChatGPT Integration Overview](chatgpt-integration.md)  --  the full integration
-- [Benefits of MCP for Business](benefits-of-mcp-for-business.md)  --  why MCP wins
-- [MCP for Operations](mcp-for-operations.md)  --  MCP for ops teams
-- [Monday.com Connector Reference](connect-monday-com-to-chatgpt.md)  --  technical details
-- [MCP vs. API Integrations](mcp-vs-api-integrations.md)  --  detailed comparison
 
 [Content truncated; see the canonical page for the complete text.]
 
@@ -7951,11 +7916,11 @@ The Notion integration provides layered security:
 
 - **Integration Token** with read-only capabilities. No content creation, editing, or deletion.
 - **Page-Level Sharing.** You explicitly share each top-level page and database with the integration. Unshared pages are inaccessible regardless of workspace membership.
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Scoped direct-MCP retention.** Notion retrieval tools are marked read-only. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 - **TLS 1.3 Encryption.** All data in transit is encrypted.
-- **Token Revocation.** Revoke the integration token from Notion at any time to immediately cut off access.
+- **Provider authorization.** Manage the integration token through Notion; provider-side timing remains governed by Notion.
 
-For organizations with sensitive documentation  --  IP, strategy, customer data  --  this architecture provides granular access control: expose only the pages you want ChatGPT to access, and revoke access instantly if needed.
+For organizations with sensitive documentation  --  IP, strategy, customer data  --  this architecture provides granular access control: expose only the pages you want ChatGPT to access, and manage provider authorization in Notion when needed.
 
 [Content truncated; see the canonical page for the complete text.]
 
@@ -8250,7 +8215,7 @@ CorpusIQ connects to your QuickBooks Online company file via OAuth 2.0. You auth
 <details>
 <summary><strong>Is this read-only? Can ChatGPT modify my books?</strong></summary>
 
-Yes, entirely read-only. CorpusIQ requests read-only OAuth scopes from Intuit. ChatGPT can view your P&L, balance sheet, invoices, payments, customers, vendors, and chart of accounts. It cannot create invoices, record payments, modify journal entries, or alter anything in your QuickBooks file. The read-only guarantee is enforced at the OAuth permission layer and at the MCP server tool level.
+The QuickBooks retrieval tools documented here are marked read-only and cover reports, invoices, payments, customers, vendors, and accounts. Provider scopes are those required by Intuit for the documented operations; write-capable tools, when present, are separately named and annotated.
 </details>
 
 <details>
@@ -8305,7 +8270,7 @@ CorpusIQ uses your QuickBooks default reporting basis. If your company is set to
 
 The architecture is clean and secure:
 
-1. **Connect QuickBooks to CorpusIQ.** Click Connections → QuickBooks in your CorpusIQ dashboard. Sign into Intuit, select your company file, and approve read-only access. Takes 2 minutes.
+1. **Connect QuickBooks to CorpusIQ.** Click Connections → QuickBooks in your CorpusIQ dashboard. Sign into Intuit, select your company file, and review and approve the provider scopes. Takes 2 minutes.
 
 2. **Connect CorpusIQ to ChatGPT.** Add the CorpusIQ MCP server as a connected app in ChatGPT. The server advertises its available financial tools to ChatGPT automatically.
 
@@ -8351,11 +8316,11 @@ Start every morning by asking ChatGPT: "What's our cash position today?" "Any pa
 
 ## Security: Read-Only by Design
 
-CorpusIQ's QuickBooks integration is read-only at every layer:
+CorpusIQ publishes operation-level permissions for QuickBooks:
 
-- **OAuth Scopes:** Only read permissions are requested from Intuit  --  no write, modify, or delete scopes.
-- **MCP Tools:** The QuickBooks connector tools are query-only  --  P&L report, invoice list, balance sheet, AR aging, customer list. There is no tool to create, update, or delete anything.
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Provider scopes:** CorpusIQ requests the Intuit scopes required for documented operations.
+- **MCP tools:** Retrieval and write-capable operations are separately named and safety-annotated.
+- **Scoped direct-MCP retention.** QuickBooks retrieval tools are marked read-only. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 - **Encrypted in Transit:** All data between QuickBooks, CorpusIQ, and ChatGPT is encrypted via TLS 1.3.
 
 For organizations in regulated industries, this read-only architecture eliminates the most common financial data risk: unintended modification. Even a misdirected query cannot change your books.
@@ -8398,7 +8363,7 @@ QuickBooks contains your company's financial truth  --  profit and loss, balance
 - **AR/AP visibility.** Ask "Which customers owe us more than $5,000?" or "What bills are due next week?" without digging through QuickBooks screens.
 - **Cross-source financial intelligence.** Combine QuickBooks data with Shopify revenue, Stripe payments, or Salesforce pipeline for a complete financial picture.
 - **Cash flow at your fingertips.** Claude can analyze your balance sheet, AR aging, and AP aging together to give you an instant cash position assessment.
-- **Read-only security.** OAuth 2.0 with read-only scope. Claude can analyze your financial data but can never create, modify, or delete transactions.
+- **Operation-level safety.** QuickBooks retrieval tools are marked read-only; write-capable tools, when present, are separately named and annotated.
 
 ### How It Works
 
@@ -8409,7 +8374,7 @@ The CorpusIQ MCP architecture for QuickBooks follows the same secure pattern as 
 3. **CorpusIQ translates** your question into the appropriate QuickBooks API calls and executes them with your stored credentials.
 4. **Claude presents** the results in natural language, with calculated metrics, trend observations, and actionable context.
 
-The connection is always live  --  every question triggers a fresh API call, so you're never looking at stale financial data.
+Each question requests current QuickBooks data. Freshness follows QuickBooks and CorpusIQ cache behavior; verify time-sensitive values against cited records.
 
 ### Setup Steps
 
@@ -8458,8 +8423,8 @@ Financial data is among the most sensitive information in any organization. Corp
 
 - **Read-only OAuth 2.0.** Claude can query financial data but can never create journal entries, modify invoices, or delete transactions.
 - **Documented controls.** CorpusIQ maintains a SOC 2 aligned posture and is CASA Tier 2 certified by DEKRA; formal SOC 2 certification is not claimed.
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
-- **Instant revocability.** Disconnect QuickBooks from CorpusIQ or revoke the Intuit token at any time.
+- **Scoped direct-MCP retention.** QuickBooks retrieval tools are marked read-only. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Disconnect behavior.** CorpusIQ disconnect commits inactive connection state and requires reauthorization; provider authorization remains governed by Intuit.
 - **Audit trail.** All queries through CorpusIQ are logged, giving your compliance team visibility into who asked what and when.
 
 ### Comparison: MCP vs. Direct QuickBooks API
@@ -8506,7 +8471,7 @@ The integration supports QuickBooks Online. QuickBooks Desktop is not currently 
 <details>
 <summary><strong>Can Claude create invoices or journal entries?</strong></summary>
 
-No. The integration is strictly read-only. Claude can analyze and report on financial data but cannot create, modify, or delete anything in QuickBooks.
+The advertised QuickBooks retrieval tools are read-only and do not create, modify, or delete records. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>
@@ -8726,7 +8691,7 @@ Salesforce is powerful but complex. The average enterprise Salesforce org has hu
 - **Cross-source enterprise intelligence.** Combine Salesforce pipeline with NetSuite financials, Stripe billing, or Snowflake analytics.
 - **Meeting intelligence.** Before any customer call, ask Claude for the account's full history  --  opportunities, cases, recent activity.
 - **Forecasting support.** Claude can analyze pipeline velocity, historical close rates, and current opportunities to support forecast discussions.
-- **Read-only security.** OAuth 2.0 with read-only scope. Claude can never modify your Salesforce data.
+- **Operation-level safety.** Retrieval tools are marked read-only; write-capable tools, when present, are separately named and annotated.
 
 ### How It Works
 
@@ -8796,7 +8761,7 @@ CorpusIQ queries standard Salesforce REST API endpoints. Custom objects accessib
 <details>
 <summary><strong>Can Claude modify Salesforce records?</strong></summary>
 
-No. The integration is strictly read-only.
+The advertised Salesforce retrieval tools are read-only. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>
@@ -9145,7 +9110,7 @@ CorpusIQ uses the Model Context Protocol (MCP)  --  an open standard for connect
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only OAuth scopes from Shopify. ChatGPT can see orders, products, customers, and store analytics. It cannot create orders, modify products, issue refunds, change prices, or alter anything in your store. The worst that can happen is an incorrect answer  --  never an incorrect database update.
+Yes. CorpusIQ requests read-only external-source retrieval scopes from Shopify. ChatGPT can see orders, products, customers, and store analytics. It cannot create orders, modify products, issue refunds, change prices, or alter anything in your store. The worst that can happen is an incorrect answer  --  never an incorrect database update.
 </details>
 
 <details>
@@ -9194,7 +9159,7 @@ CorpusIQ offers a free 30-day trial that includes the Shopify connector. After t
 
 The architecture is straightforward. CorpusIQ acts as a secure MCP bridge between ChatGPT and your Shopify store. Here's the flow:
 
-1. **Connect Shopify to CorpusIQ.** You authorize CorpusIQ to access your Shopify store via read-only OAuth. This takes about 2 minutes  --  enter your store's myshopify.com domain, sign into Shopify, and approve the requested scopes.
+1. **Connect Shopify to CorpusIQ.** You authorize CorpusIQ to access your Shopify store via read-only external-source retrieval. This takes about 2 minutes  --  enter your store's myshopify.com domain, sign into Shopify, and approve the requested scopes.
 
 2. **Connect CorpusIQ to ChatGPT.** In ChatGPT, you add the CorpusIQ MCP server as a connected app. ChatGPT discovers all your connected data sources automatically. See our [ChatGPT integration guide](chatgpt-integration.md) for step-by-step instructions.
 
@@ -9342,7 +9307,7 @@ Once connected, Claude can answer an enormous range of Shopify questions. Here a
 
 ### Security and Permissions
 
-CorpusIQ uses OAuth 2.0 with read-only scope for the Shopify integration. This means:
+Shopify provider scopes vary by documented operation. The retrieval tools described here are marked read-only:
 
 - **Claude can read** your orders, products, customers, and analytics.
 - **Claude can never write**  --  it cannot create, update, or delete anything in your Shopify store.
@@ -9382,13 +9347,13 @@ No. The OAuth flow is point-and-click. Anyone with Shopify admin access can conn
 <details>
 <summary><strong>Can Claude modify my Shopify store  --  create products, update orders, or change prices?</strong></summary>
 
-No. The integration is strictly read-only. Claude can query your data but cannot make any changes to your Shopify store.
+The advertised Shopify retrieval tools are read-only and do not change the store. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>
 <summary><strong>How current is the data Claude sees?</strong></summary>
 
-Real-time. Every question you ask triggers a fresh API call to Shopify. Claude always works with live data, not cached snapshots.
+Each question requests current Shopify data. Freshness follows Shopify and CorpusIQ cache behavior; use cited source records for time-sensitive verification.
 </details>
 
 <details>
@@ -9400,7 +9365,7 @@ The integration works with any Shopify plan that includes API access. Most plans
 <details>
 <summary><strong>Can I limit which data Claude can access?</strong></summary>
 
-Yes. The OAuth scope is read-only across orders, products, customers, and analytics. You can further restrict access by only granting specific scopes during authorization.
+Yes. The advertised Shopify retrieval tools for orders, products, customers, and analytics are marked read-only; write-capable tools, when available, are separately named and annotated. You can further restrict access by only granting specific scopes during authorization.
 </details>
 
 <details>
@@ -9466,7 +9431,7 @@ CorpusIQ connects to your Slack workspace via OAuth 2.0. You authorize read-only
 <details>
 <summary><strong>Is the connection read-only?</strong></summary>
 
-Yes. CorpusIQ requests read-only OAuth scopes from Slack. ChatGPT can read channels, search messages, retrieve threads, and access workspace analytics. It cannot send messages, create channels, modify workspace settings, or perform any write operation. The read-only guarantee is enforced by the Slack OAuth scopes requested during authorization.
+Yes. CorpusIQ requests read-only external-source retrieval scopes from Slack. ChatGPT can read channels, search messages, retrieve threads, and access workspace analytics. It cannot send messages, create channels, modify workspace settings, or perform any write operation. The advertised Slack retrieval tools are marked read-only; write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>
@@ -9661,7 +9626,7 @@ Claude can search across public channels and private channels it has been added 
 A: Claude can only access public channels and private channels it has been explicitly added to. Direct messages are never accessible.
 
 **Q: Can Claude send messages to Slack?**
-A: No. The integration is strictly read-only.
+A: The advertised Slack retrieval tools are read-only and do not send messages. Write-capable tools, when available, are separately named and annotated.
 
 **Q: How far back can Claude search?**
 A: Claude can search your entire message history, subject to your Slack workspace's retention settings.
@@ -9945,7 +9910,7 @@ CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain
 <details>
 <summary><strong>Can Claude create charges or modify subscriptions?</strong></summary>
 
-No. The integration is strictly read-only. Use a restricted API key with only read permissions.
+The advertised Stripe retrieval tools use restricted read access and do not create charges or modify subscriptions. Write-capable tools, when available, are separately named and annotated.
 </details>
 
 <details>
@@ -9996,7 +9961,7 @@ URL: https://www.corpusiq.io/docs/connectors/
 Connect QuickBooks, Shopify, Stripe, HubSpot, GA4, and 35+ more business tools to ChatGPT, Claude, and Perplexity through read-only direct MCP live retrieval. CorpusIQ does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days. Browse the complete directory below.
 # Connectors
 
-CorpusIQ integrates with 40+ business tools through read-only OAuth connections. Each connector maps to a specific SaaS application or database, enabling natural-language queries across your entire data stack.
+CorpusIQ integrates with 40+ business tools through source-specific authorization. Each connector maps to a SaaS application or database, and each published operation declares whether it is read-only or write-capable.
 
 For the full interactive connector list with real-time status indicators, visit [corpusiq.io/connectors](https://corpusiq.io/connectors).
 
@@ -10101,14 +10066,14 @@ For the full interactive connector list with real-time status indicators, visit 
 
 ## Connecting a New Service
 
-All connectors use read-only OAuth scopes. To connect a new service:
+Each connector requests the provider scopes needed for its documented operations. To connect a new service:
 
 1. Log in to the [CorpusIQ Dashboard](https://corpusiq.io/dashboard)
 2. Navigate to **Connections**
 3. Click the service you want to connect
 4. Complete the OAuth authorization flow
 
-CorpusIQ never requests write permissions. You can verify the exact OAuth scopes requested on the authorization screen.
+You can verify the exact provider scopes requested on the authorization screen and inspect each MCP tool's safety annotations.
 
 ## Connector Status
 
@@ -10119,13 +10084,13 @@ For the latest connector count and status, visit [corpusiq.io/connectors](https:
 ## Frequently Asked Questions
 
 **Q: How many connectors does CorpusIQ support?**  
-A: CorpusIQ supports 40+ native connectors spanning CRM, accounting, payments, analytics, marketing, ecommerce, file storage, communication, databases, and more. All connectors are read-only via OAuth.
+A: CorpusIQ supports 40+ native connectors spanning CRM, accounting, payments, analytics, marketing, ecommerce, file storage, communication, databases, and more. External-source retrieval and write-capable management/control-plane operations are separately named and annotated.
 
 **Q: How do I connect a new data source?**  
 A: Log into the CorpusIQ Dashboard, navigate to Connections, click the service you want to connect, and complete the OAuth authorization flow. Each connection takes under 60 seconds.
 
 **Q: Are CorpusIQ connectors read-only?**  
-A: Yes. All connectors use read-only OAuth scopes. CorpusIQ never requests write permissions. You can verify the exact scopes on the OAuth authorization screen during connection setup.
+A: External-source retrieval tools are marked read-only. Write-capable connector-management and CorpusIQ control-plane tools are separately named and annotated. Provider scopes vary by connector and are shown during authorization.
 
 **Q: Does CorpusIQ support database connections?**  
 A: Yes. CorpusIQ supports PostgreSQL, MSSQL (SQL Server), MySQL, Azure Cosmos DB, and MongoDB  --  all with read-only SQL/query access.
@@ -10500,7 +10465,7 @@ Fivetran is the leading managed ETL (Extract, Transform, Load) platform, automat
 
 **Fivetran's model:** Extract data from source → transform it → load it into a warehouse → query the warehouse with SQL or BI tools.
 
-**CorpusIQ's model:** AI asks a question → CorpusIQ queries the live source via API → AI presents the answer. No intermediate copy.
+**CorpusIQ's model:** AI asks a question → CorpusIQ queries the live source via API → AI presents the answer. Direct MCP does not retain raw customer files or full connector response payloads; optional indexed search is separate.
 
 This architectural difference has cascading implications for cost, speed, freshness, and complexity.
 
@@ -10509,13 +10474,13 @@ This architectural difference has cascading implications for cost, speed, freshn
 | Feature | CorpusIQ | Fivetran |
 |---------|----------|----------|
 | **Approach** | Real-time API query (MCP) | Batch ETL pipelines |
-| **Data Freshness** | Instant  --  queries live source | 5 min to 24 hours (sync frequency) |
+| **Data Freshness** | Requested from the provider; freshness follows provider and cache behavior | 5 min to 24 hours (sync frequency) |
 | **Source-data replication** | No raw-file/full-payload warehouse | Full replication to warehouse |
 | **Infrastructure Required** | None | Data warehouse (Snowflake, BigQuery, etc.) |
 | **Setup Complexity** | 2-minute OAuth | Hours to days (connector + warehouse config) |
 | **AI Integration** | Native MCP protocol | Indirect (SQL queries via warehouse) |
 | **Cost Model** | Per-seat subscription | Per-row (MAR) + warehouse costs |
-| **Data Storage** | No replicated source-data warehouse; scoped operational logs up to 30 days | Permanent warehouse copy |
+| **Data Storage** | Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may persist up to 30 days | Permanent warehouse copy |
 | **Schema Management** | Automatic (API-driven) | Manual schema changes, dbt transforms |
 | **Use Case** | AI-powered business questions | Centralized analytics and reporting |
 
@@ -10527,7 +10492,7 @@ Every source-data copy creates a governance, security, and freshness burden. Cor
 **Why this matters:** GDPR compliance, SOC 2 audits, and internal data governance all become simpler when you don't maintain additional copies of sensitive business data.
 
 ### 2. Real-Time Freshness
-Fivetran syncs on a schedule  --  every 5 minutes, every hour, every 24 hours. That means your warehouse data is always slightly stale. CorpusIQ queries live APIs on every request, so you always get the current state of your business.
+Fivetran syncs on a schedule  --  every 5 minutes, every hour, every 24 hours. That means your warehouse data is always slightly stale. CorpusIQ requests current provider data for each query; freshness follows provider behavior and any documented CorpusIQ caching.
 
 **Example:** You just closed a $50K deal in HubSpot. With CorpusIQ, an AI query 30 seconds later reflects that deal. With Fivetran, you wait until the next sync  --  potentially hours.
 
@@ -10887,7 +10852,7 @@ CorpusIQ is designed for structured business data where accuracy, freshness, and
 | **Completeness** | Returns all matching records | Returns top-k similar results |
 | **Aggregation** | Native (SUM, COUNT, AVG via API) | Not supported |
 | **Setup** | 2-minute OAuth | Hours to days (chunking, embedding, indexing) |
-| **Data Movement** | None (queries source) | Full copy to vector store |
+| **Data path** | Direct MCP queries sources live; optional indexed search is separate | Full copy to vector store |
 | **Cost** | Per-seat subscription | Per-vector storage + compute |
 
 ## When Vector Databases Excel
@@ -11083,18 +11048,18 @@ CorpusIQ and Zapier both connect business tools  --  but they do so in fundament
 | **Core Paradigm** | AI-native data access (MCP) | Event-driven workflow automation |
 | **Primary Use Case** | Natural-language business queries | Automating repetitive tasks |
 | **AI Integration** | Native (MCP protocol) | Limited (ChatGPT plugin, webhooks) |
-| **Data Flow** | Read-only, real-time query | Write/trigger actions between apps |
+| **Data Flow** | Retrieval and write-capable operations are separately named and annotated | Write/trigger actions between apps |
 | **Setup Time** | Under 2 minutes | 5-30 minutes per Zap |
 | **Real-Time Queries** | Yes  --  live, on-demand | No  --  event-triggered only |
 | **Cross-Source Analysis** | Multi-source queries in one prompt | Sequential Zaps with delays |
-| **Data Storage** | No replicated source-data warehouse; scoped operational logs up to 30 days | May store data in Zapier Tables |
+| **Data Storage** | Direct MCP does not retain raw customer files or full connector response payloads; scoped operational logs may persist up to 30 days | May store data in Zapier Tables |
 | **Pricing Model** | Per-seat subscription | Per-task / per-Zap |
 
 ## How CorpusIQ Works
 
 CorpusIQ implements the **Model Context Protocol (MCP)**  --  an open standard developed by Anthropic that lets AI models discover and invoke tools. When you connect a data source to CorpusIQ (HubSpot, QuickBooks, Stripe, Google Analytics, etc.), the platform exposes that data as typed MCP tools that AI assistants can call.
 
-The AI never sees your raw data unless you ask it to  --  it sees structured function signatures and results, which it interprets and presents in natural language. Every query runs against the live source.
+The AI receives the tool definitions and results needed for the request. Retrieval requests current provider data; freshness follows provider behavior and documented CorpusIQ caching.
 
 ## How Zapier Works
 
@@ -11241,7 +11206,7 @@ Giving an AI assistant access to enterprise business data sounds simple: connect
 
 - **Data residency.** Global enterprises should validate the complete processing path: storage, network transit, source-provider processing, the selected AI client, logs, and backups. Choosing a regional CorpusIQ deployment alone does not guarantee that every dependency remains in-region.
 
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Scoped direct-MCP retention.** External-source retrieval tools are marked read-only. The direct MCP path does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 
 - **Compliance certifications.** The solution must hold relevant certifications  --  SOC 2 Type II at minimum  --  and support the enterprise's own compliance frameworks including GDPR, CCPA, and industry-specific regulations.
 
@@ -11261,7 +11226,7 @@ CorpusIQ's enterprise AI data access architecture is built on five pillars:
 
 **Multi-factor authentication enforcement.** MFA is enforced at the identity provider level. CorpusIQ inherits the MFA policies already configured in Okta or Azure AD  --  including hardware token requirements, biometric authentication, and conditional access policies.
 
-**Per-user OAuth scoping.** When a user connects a data source through OAuth, the scopes granted are the minimum necessary for read-only business intelligence. Each user authenticates individually  --  there are no shared service accounts that would obscure who accessed what data.
+**Per-user OAuth scoping.** When a user connects a data source through OAuth, CorpusIQ requests provider scopes required for the documented operations. Retrieval and write-capable tools remain separately named and annotated regardless of provider scope grouping. Each user authenticates individually  --  there are no shared service accounts that would obscure who accessed what data.
 
 ### 2. Read-Only External Retrieval with Explicit Control-Plane Writes
 
@@ -11269,13 +11234,13 @@ CorpusIQ separates external-source retrieval from writes to user-declared Corpus
 
 - **Protocol level.** External-source retrieval tools carry read-only annotations. Explicit control-plane tools that update or remove user-declared facts, decisions, metric specifications, and source manifests carry separate non-read-only and destructive annotations where applicable.
 
-- **OAuth scope level.** External-source connectors request the documented retrieval scopes. For QuickBooks, `com.intuit.quickbooks.accounting.read`. For Shopify, `read_orders`, `read_products`, `read_customers`. For HubSpot, read-only access to contacts, deals, and companies.
+- **OAuth scope level.** External-source connectors request the provider scopes required for their documented operations. When a provider groups permissions into a broader scope, CorpusIQ still exposes retrieval and write-capable operations as separately named, safety-annotated tools.
 
-- **Connector level.** External-source connector implementations validate operations against a capability matrix and block write-back operations to connected vendor systems.
+- **Connector level.** External-source retrieval implementations validate operations against a capability matrix and block write-back. Write-capable connector operations, when exposed, are separately named and annotated.
 
 - **AI model level.** External connector descriptions identify retrieval behavior, while CorpusIQ control-plane descriptions state the supported state mutation explicitly.
 
-This defense-in-depth approach prevents external connector tools from writing back to connected vendor systems. Supported CorpusIQ control-plane mutations remain explicit, user-invoked, separately annotated, and auditable.
+This defense-in-depth approach keeps retrieval tools from writing back. Supported write-capable connector and CorpusIQ control-plane mutations remain explicit, separately named, and safety-annotated.
 
 ### 3. Comprehensive Audit Trails
 
@@ -11308,13 +11273,13 @@ Operational logs are protected from user edits and retained for up to 30 days un
 
 CorpusIQ's direct MCP path uses live retrieval with scoped operational retention:
 
-- **Scoped direct-MCP retention.** CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+- **Scoped direct-MCP retention.** External-source retrieval tools are marked read-only. The direct MCP path does not retain raw customer files or full connector response payloads; operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 
 - **Direct-MCP index scope.** The direct path uses typed API calls and does not build embeddings or file indexes; optional indexed search is separate and retains embeddings plus minimal metadata until connector revocation or account deletion.
 
 - **Fresh direct queries.** Each direct MCP query requests current source data rather than serving a persisted full-response cache.
 
-- **No cross-tenant data mixing.** Each enterprise customer's queries are processed in isolated compute environments. Data from one customer is never co-located with data from another.
+- **Tenant isolation.** Authentication and token lookup are user-scoped; multi-tenant infrastructure does not imply shared authorization or cross-tenant result access.
 
 CorpusIQ stores encrypted authentication tokens and connector configuration while connections are active. Local AUDIT logs record raw query text and tool parameters plus bounded result summaries; the Azure Log Analytics workspace retains those logs for 30 days. Optional indexed search has a separate embeddings and minimal-metadata lifecycle.
 
@@ -11339,8 +11304,6 @@ The question every enterprise faces: build an AI data access layer in-house or a
 **Read-only enforcement.** Build a capability matrix that validates every API call against allowed operations. Implement at the API gateway, service, and connector levels. **Engineering effort: 2–3 weeks.**
 
 **Audit logging.** Build an audit logging system with immutable storage, structured log format, SIEM export, configurable retention, and real-time streaming. **Engineering effort: 3–5 weeks.**
-
-**AI model integration.** Build the tool discovery, function calling, and response synthesis layer that connects AI models to your data connectors. Handle prompt engineering, context window management, tool selection logic. **Engineering effort: 6–12 weeks.**
 
 [Content truncated; see the canonical page for the complete text.]
 
@@ -11650,7 +11613,7 @@ CorpusIQ's authentication model:
 
 **OAuth 2.0 for cloud services.** Each business platform (Shopify, QuickBooks, HubSpot, etc.) is connected through OAuth 2.0. Users authorize CorpusIQ to access their data with explicitly scoped permissions. Tokens are stored encrypted at rest and rotated automatically.
 
-**Read-only by default.** Every connector defaults to read-only access. Write operations require explicit opt-in at both the OAuth scope level and the MCP server configuration level. This dual-gate approach prevents accidental data modification.
+**Operation-level safety metadata.** External-source retrieval tools carry read-only annotations. Write-capable connector-management and CorpusIQ control-plane tools are separately named and annotated for their actual behavior.
 
 **Token isolation.** Each user's OAuth tokens are cryptographically isolated. No user can access another user's data, even within the same CorpusIQ organization.
 
@@ -11908,7 +11871,7 @@ Whether you're a business owner checking financial health, an accountant prepari
 Before diving into analysis, you need to connect QuickBooks to an AI assistant through CorpusIQ's MCP platform. Here's the setup process:
 
 ### 1. Connect QuickBooks to CorpusIQ
-Navigate to your CorpusIQ dashboard and select "Connect QuickBooks." Sign in on Intuit's OAuth page and authorize the read-only connection. Direct MCP requests then fetch QuickBooks records live; CorpusIQ does not retain raw customer files or full connector response payloads. Operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
+Navigate to your CorpusIQ dashboard and select "Connect QuickBooks." Sign in on Intuit's OAuth page and review and approve the provider scopes. Direct MCP requests then fetch QuickBooks records live; CorpusIQ does not retain raw customer files or full connector response payloads. Operational logs retain query text, per-user tool-call metadata, and bounded outcome summaries for up to 30 days.
 
 ### 2. Configure Your AI Assistant
 CorpusIQ supports both ChatGPT and Claude as AI backends. Choose based on your analysis needs:
@@ -13892,7 +13855,7 @@ URL: https://www.corpusiq.io/docs/hubspot-business-intelligence/
 
 HubSpot is one of the world's most widely adopted CRM platforms, used by over 200,000 businesses to manage contacts, deals, companies, and customer relationships. But while HubSpot excels at storing and organizing data, extracting real-time business intelligence from that data often requires exporting to spreadsheets, building custom dashboards, or relying on HubSpot's built-in reporting  --  which, while capable, can't answer free-form business questions in natural language.
 
-CorpusIQ changes that. Using the **Model Context Protocol (MCP)**  --  the open standard for connecting data to AI  --  CorpusIQ enables any MCP-compatible AI assistant to query your HubSpot CRM live, in real time, without moving, copying, or duplicating your data.
+CorpusIQ changes that. Using the **Model Context Protocol (MCP)**  --  the open standard for connecting data to AI  --  CorpusIQ enables any MCP-compatible AI assistant to query HubSpot through live retrieval. Direct MCP does not retain raw customer files or full connector response payloads; operational logs and optional indexed search follow their published lifecycles.
 
 ## How It Works
 
@@ -14070,7 +14033,7 @@ Different stakeholders need different views:
 - **Sales Ops Dashboard**: Deal hygiene, process adherence, data quality, system health
 
 ### 3. Real-Time Data Refresh
-Every dashboard pull queries HubSpot live. If a rep updated a deal 30 seconds ago, it's reflected in your dashboard now. No batch delays, no cache staleness, no waiting for overnight refreshes. This is critical during end-of-quarter when deal statuses change minute by minute.
+Every dashboard pull queries HubSpot live. If a rep updated a deal 30 seconds ago, it's reflected in your dashboard now. Queries request current HubSpot data. Freshness follows HubSpot and CorpusIQ cache behavior. This is critical during end-of-quarter when deal statuses change minute by minute.
 
 ### 4. Intelligent Alerting
 ChatGPT doesn't just display numbers  --  it interprets them against your targets and historical patterns. "Pipeline coverage is 2.8x, below our 3x target. However, the shortfall is concentrated in early-stage pipeline  --  late-stage coverage is healthy at 1.4x. Recommended action: focus reps on prospecting this week." Context-aware alerts make dashboards actionable, not just informational.
@@ -14433,7 +14396,7 @@ URL: https://www.corpusiq.io/docs/
 A: CorpusIQ is a private AI acceleration layer that connects 40+ business tools (HubSpot, QuickBooks, Stripe, Shopify, GA4, Slack, and more) to ChatGPT, Claude, and AI agents via the Model Context Protocol (MCP). It enables real-time, natural-language queries across your data stack without storing raw customer files or full connector response payloads.
 
 **Q: How does CorpusIQ connect my business data to AI?**  
-A: CorpusIQ uses MCP (Model Context Protocol)  --  an open standard that lets AI assistants discover and use external tools. Connect your data sources via OAuth, and the AI can query them live through CorpusIQ's MCP endpoint with read-only access.
+A: CorpusIQ uses MCP (Model Context Protocol)  --  an open standard that lets AI assistants discover and use external tools. Connect your data sources through their documented authorization flows, and the AI can invoke CorpusIQ tools with operation-specific names and safety annotations.
 
 **Q: What data sources does CorpusIQ support?**  
 A: CorpusIQ supports 40+ business tools including HubSpot, Salesforce, QuickBooks, Stripe, Shopify, GA4, Google Ads, Meta Ads, Slack, Gmail, Google Drive, Notion, PostgreSQL, MSSQL, MongoDB, and more  --  see the full connectors directory.
@@ -15066,7 +15029,7 @@ Ecommerce success depends on understanding customers:
 
 **Unified connector library.** CorpusIQ connects to Shopify, Amazon, eBay, Klaviyo, Mailchimp, Google Ads, Meta Ads, Google Analytics, QuickBooks, Stripe, and more  --  all through a single MCP server.
 
-**Read-only access.** All ecommerce connectors default to read-only. You can analyze order data, inventory levels, and customer information without any risk of modifying products, orders, or settings.
+**Explicit operation boundaries.** Ecommerce retrieval tools are marked read-only. Write-capable connector-management and CorpusIQ control-plane operations are separately named and safety-annotated.
 
 **Real-time queries.** Ask about today's orders and get today's data  --  not yesterday's export. Critical for inventory decisions, fulfillment monitoring, and flash sale performance tracking.
 
@@ -15103,7 +15066,7 @@ Yes. Connect Amazon advertising data alongside order data to analyze which campa
 <details>
 <summary><strong>Is this secure for my store data?</strong></summary>
 
-Yes. All connections use OAuth with read-only scopes. CorpusIQ cannot modify your products, orders, or customer data. Connected commerce platforms remain authoritative; direct-MCP and operational-log retention follow the published lifecycles.
+Provider scopes vary by connection. The ecommerce retrieval tools documented here do not write products, orders, or customer records back to their sources; write-capable management/control-plane operations are separate. Connected commerce platforms remain authoritative, and retention follows the published lifecycles.
 </details>
 
 <details>
@@ -16280,7 +16243,7 @@ The setup process for a small business using CorpusIQ:
 
 **1. Create an account.** Sign up through the CorpusIQ platform. No credit card required to start.
 
-**2. Connect QuickBooks.** Authorize CorpusIQ to access your QuickBooks data through OAuth. The connection is read-only by default  --  CorpusIQ can read your financial data but cannot modify it.
+**2. Connect QuickBooks.** Authorize CorpusIQ to access your QuickBooks data through OAuth. The advertised financial-data retrieval tools are marked read-only. Write-capable tools, when available, are separately named and annotated.
 
 **3. Connect your CRM.** Authorize HubSpot, Salesforce, or your preferred CRM. Again, read-only access for querying contacts, deals, and pipeline data.
 
@@ -16406,7 +16369,7 @@ Security is the first question every business leader asks about AI data integrat
 
 MCP's security model rests on several architectural decisions:
 
-**Read-only by default.** The protocol itself supports both read and write operations, but the secure default  --  and the approach CorpusIQ takes  --  is to implement all business intelligence connectors as read-only. The AI model can query data but cannot modify it.
+**Operation-level safety.** MCP supports reads and writes. CorpusIQ marks external-source retrieval tools read-only and exposes write-capable connector-management and CorpusIQ control-plane tools separately with behavior-matched annotations.
 
 **OAuth 2.0 authentication.** Every connection to a third-party platform uses OAuth 2.0, the industry standard for delegated authorization. Users grant CorpusIQ specific, scoped permissions rather than sharing credentials.
 
@@ -16421,10 +16384,10 @@ CorpusIQ uses read-only access for direct MCP live retrieval. It does not retain
 OAuth 2.0 scopes determine what an MCP server can do with a connected platform. Best practice is to request the minimum scopes necessary for the intended use case.
 
 CorpusIQ's approach:
-- **Read-only scopes by default.** For QuickBooks, we request `com.intuit.quickbooks.accounting.read`  --  not the broader scope that includes write access. For Shopify, we request `read_orders`, `read_products`, `read_customers`  --  not `write_orders` or `write_products`.
-- **Explicit opt-in for write operations.** If a use case requires write access (for example, creating draft invoices), the user must explicitly approve additional scopes. This is a deliberate friction point  --  it ensures write access is never granted accidentally.
-- **Per-connector scope configuration.** Each connected platform has independently configured scopes. Granting write access to your email marketing platform doesn't grant write access to your accounting system.
-- **Scope visibility.** Users can see exactly which scopes are granted to each connection at any time through the CorpusIQ dashboard.
+- **Source-specific scopes.** CorpusIQ requests the provider scopes needed for each documented operation. Read-only retrieval tools and write-capable connector-management or control-plane tools remain separately named and safety-annotated even when a provider groups permissions into broader scopes.
+- **Explicit operation boundaries.** Read-only retrieval tools and write-capable connector-management or CorpusIQ control-plane tools are separately named and carry explicit safety annotations.
+- **Per-connector scope configuration.** Each connected platform has independently configured scopes. One connector's authorization does not widen another connector's access.
+- **Scope visibility.** The provider authorization screen displays the requested source scopes. CorpusIQ tool names and annotations disclose whether each published operation is read-only or write-capable.
 
 ## Token Management
 
@@ -16440,19 +16403,19 @@ OAuth tokens are the keys to your data. Managing them securely is critical:
 
 **Cross-user isolation.** Each user's tokens are cryptographically isolated. User A's Shopify token cannot be used to access User B's data, even if both users are in the same CorpusIQ organization. This isolation extends to the database layer  --  tokens are stored with user-scoped encryption keys.
 
-## Read-Only Architecture Deep Dive
+## Tool Boundary Architecture Deep Dive
 
-The read-only default deserves deeper examination because it's the most important security property of the system.
+The distinction between read-only retrieval and write-capable CorpusIQ-owned state changes deserves deeper examination.
 
-**Protocol-level enforcement.** CorpusIQ's MCP server validates every tool call against a capability matrix. Tools marked as read-only cannot be used to execute write operations, regardless of what OAuth scopes are granted.
+**Protocol-level enforcement.** CorpusIQ's MCP server validates every tool call against a capability matrix. Tools marked as read-only cannot execute write operations. Write-capable connector-management and control-plane tools are separately named and annotated.
 
-**API-level guardrails.** Even with write OAuth scopes, CorpusIQ's connector implementations include additional validation. An API call that would modify data is blocked at the connector level unless the connector is explicitly configured to allow writes.
+**API-level guardrails.** Connector implementations validate the requested operation and source-specific authorization. A write-capable tool can execute only its declared action; it does not silently widen a read-only retrieval call.
 
-**AI model guardrails.** The MCP tool definitions presented to the AI model describe read-only capabilities. The model sees "List Shopify Orders"  --  not "Create Shopify Order." This means the AI model itself cannot request write operations unless they've been explicitly exposed.
+**AI-client visibility.** MCP tool definitions expose operation-specific names, descriptions, schemas, and safety annotations. Clients can distinguish retrieval tools from write-capable connector-management and CorpusIQ control-plane tools before invocation.
 
-**Human approval for writes.** In the rare cases where write operations are enabled, CorpusIQ can require human confirmation before execution. The AI model proposes the action, and a human user must approve it before the MCP server executes it.
+**Invocation remains explicit.** A write-capable operation runs only when that separately named tool is invoked with valid parameters and authorization. Client confirmation behavior is governed by the selected AI client's interface and policy.
 
-This defense-in-depth approach  --  protocol, API, AI model, and human approval  --  means that write operations require multiple deliberate choices to enable. Accidental data modification is architecturally prevented.
+This defense-in-depth approach makes write-capable operations visible and bounded. It reduces unintended-change risk without claiming that modification is architecturally impossible.
 
 ## Audit Trails
 
@@ -16702,7 +16665,7 @@ Key CorpusIQ features that go beyond raw API access:
 
 **Canonical definitions.** Declare how key business terms should be interpreted, and the AI model applies those definitions consistently across all data sources.
 
-**Read-only guardrails.** Every connector defaults to read-only. No accidental data modification, no matter what the AI model requests.
+**Explicit tool boundaries.** External-source retrieval tools are marked read-only. Write-capable connector-management and CorpusIQ control-plane operations are separately named and safety-annotated.
 
 **Audit trail.** Every tool call is logged, giving you complete visibility into what data was accessed and when.
 
@@ -16723,7 +16686,7 @@ Yes. MCP tool definitions include rich parameter schemas that support pagination
 <details>
 <summary><strong>What if I need to write data, not just read it?</strong></summary>
 
-MCP supports write operations, but CorpusIQ defaults to read-only for safety. Write operations require explicit opt-in. For most business intelligence use cases, read-only is exactly what you need.
+A: MCP supports both reads and writes. CorpusIQ exposes retrieval and write-capable operations as separately named tools with behavior-matched safety annotations.
 </details>
 
 <details>
@@ -17119,7 +17082,7 @@ Not entirely  --  they serve different purposes. Zapier excels at automated acti
 <details>
 <summary><strong>Does MCP support triggering actions?</strong></summary>
 
-The base MCP protocol supports write operations, but CorpusIQ defaults to read-only for data safety. For automation workflows that require write operations, Zapier or Make are better choices today. CorpusIQ focuses on the intelligence layer.
+The base MCP protocol supports reads and writes. CorpusIQ marks external-source retrieval tools read-only and exposes write-capable management/control-plane operations separately; Zapier and Make remain focused on multi-step vendor automation.
 </details>
 
 <details>
@@ -17337,7 +17300,7 @@ Create an account at [corpusiq.io/register](https://corpusiq.io/register). You c
 3. Click **Add Connection** on any service you want to connect
 4. Complete the OAuth authorization flow
 
-CorpusIQ uses **read-only OAuth scopes**  --  it can search your data but never modify it. The exact permissions are displayed on the authorization screen.
+Provider scopes vary by connector and are displayed on the authorization screen. External-source retrieval tools are marked read-only; write-capable management/control-plane tools are separately named and annotated.
 
 Popular first connections:
 - **Gmail**  --  Search your email history
@@ -17423,7 +17386,6 @@ curl -X POST https://mcp2.corpusiq.io/mcp \
 curl -X POST https://mcp2.corpusiq.io/mcp \
   -H "Authorization: Bearer $CORPUSIQ_TOKEN" \
   -H "Content-Type: application/json" \
-  -H "Idempotency-Key: $(uuidgen)" \
   -d '{"query": "How many HubSpot deals closed this quarter?"}'
 ```
 
@@ -17796,7 +17758,7 @@ Through CorpusIQ, you define what matters to your business. Create dashboard tem
 - **Operations Dashboard**: Expense trends, vendor spend, inventory metrics
 
 ### 3. Real-Time Data Refresh
-Every dashboard pull queries QuickBooks live  --  there's no stale cache. The numbers you see reflect the current state of your books, not last week's export. This is critical for cash flow monitoring and AR management where hour-level freshness matters.
+Dashboard pulls query QuickBooks at request time. Freshness follows QuickBooks and CorpusIQ cache behavior, so verify time-sensitive figures against the cited source record.
 
 ### 4. Anomaly Highlighting
 ChatGPT doesn't just present numbers  --  it flags what needs attention. "Your gross margin dropped 3.2 percentage points this month  --  the largest one-month decline in 18 months. The primary driver was a 15% increase in COGS for the Widget product line." These contextual alerts turn raw data into actionable intelligence.
@@ -18207,7 +18169,7 @@ CorpusIQ provides natural language search across all 36 connected business data 
 
 - Natural language queries (no SQL required)
 - Cross-source search (query Stripe AND Shopify in one question)
-- Real-time results (no cached or stale data)
+- Live source queries; provider and transport caching behavior may vary
 - Date range filtering
 - Aggregation and summarization
 - Trend analysis
@@ -18426,7 +18388,7 @@ URL: https://www.corpusiq.io/docs/security/
 
 
 title: "CorpusIQ Security Overview  --  Authentication, Encryption, and Read-Only Access"
-description: "CorpusIQ security overview: OAuth 2.0 authentication for agents and chat users, TLS 1.3 encryption, read-only data access policy, audit logging, data handling, and security best practices."
+description: "CorpusIQ security overview: OAuth 2.0 authentication, operation-level permissions, encryption, audit logging, data handling, and security best practices."
 category: "Documentation"
 tags: ["corpusiq security overview", "authentication", "encryption", "read-only access", "oauth security", "data handling", "audit logging"]
 last_updated: "2026-08-12"
@@ -18435,7 +18397,7 @@ robots: "index,follow"
 ---
 # Security
 
-CorpusIQ is designed with security as a foundational requirement. External-source connector access is read-only and does not write back to vendor systems. Explicit CorpusIQ control-plane tools can update or remove user-declared CorpusIQ state and carry separate safety annotations.
+CorpusIQ is designed with security as a foundational requirement. External-source retrieval tools are marked read-only. Write-capable connector and CorpusIQ control-plane tools are separately named and carry behavior-matched safety annotations.
 
 ## Authentication
 
@@ -18449,18 +18411,18 @@ CorpusIQ is designed with security as a foundational requirement. External-sourc
 - No browser required for ongoing agent access
 - Refresh token rotation
 - Device verification prevents unauthorized access
-- Tokens can be revoked from the dashboard at any time
+- Dashboard disconnect removes CorpusIQ connection state and requires reauthorization before reuse; provider authorization remains provider-governed
 
 ### Data Source Connections
 - OAuth 2.0 authorization for each connected source
 - Scoped access: CorpusIQ requests minimum required permissions
-- Connections can be revoked individually
-- No raw API keys stored or exposed
+- CorpusIQ connections can be disconnected individually
+- Credential-based connectors store required secrets encrypted; public responses do not expose them
 
 ## Data Access
 
 ### Scoped Access Policy
-External-source connector tools use read-only retrieval: they query connected sources, normalize results, and do not write back to those vendor systems or initiate vendor transactions. Explicit CorpusIQ control-plane tools can update or remove user-declared facts, decisions, metric specifications, and source manifests and carry separate safety annotations.
+External-source retrieval tools query connected sources, normalize results, and do not write back. Write-capable connector and CorpusIQ control-plane tools are separately named and carry behavior-matched safety annotations.
 
 ### Data Handling
 - Direct MCP retrieves source records on demand and delivers scoped results to the requesting client
@@ -18496,7 +18458,7 @@ Report security concerns to security@corpusiq.io. We respond within 24 hours.
 ## Frequently Asked Questions
 
 **Q: How does CorpusIQ authenticate users?**  
-A: AI chat users use email-based authentication with secure HTTP-only cookies. AI agent users use OAuth 2.0 Device Authorization Grant (RFC 8628) with refresh token rotation. Data source connections use OAuth 2.0 with scoped, read-only permissions.
+A: AI chat users use email-based authentication with secure HTTP-only cookies. AI agent users use OAuth 2.0 Device Authorization Grant (RFC 8628) with refresh token rotation. Data-source provider scopes vary by connector and documented operation.
 
 **Q: Is CorpusIQ data access read-only?**
 A: External-source retrieval is read-only and does not write back to connected vendor systems. Explicit CorpusIQ control-plane tools can modify user-declared CorpusIQ state and are separately annotated.
@@ -18594,12 +18556,12 @@ CorpusIQ processes data under the lawful basis of user consent and legitimate in
 - **Data Minimization:** Only data necessary to answer a query is retrieved
 - **Purpose Limitation:** Retrieved records fulfill the user's request; retained operational metadata supports service security, reliability, and compliance under the published schedule
 - **No Data Sale:** CorpusIQ does not sell or monetize user data; scoped data is shared only with processors required to fulfill the request
-- **No CorpusIQ Model Training:** CorpusIQ does not use customer data to train models; each selected AI client's policy applies to its conversation
+- **No CorpusIQ Model Training:** CorpusIQ does not use customer data to train models; conversation handling follows the selected AI provider's plan and settings
 - **No Background Collection:** Every API call to a connected tool is triggered by an explicit user query. There is no periodic syncing or scheduled polling.
 
 ## 5. Retention and Deletion
 
-1. A query is received and translated into read-only API calls
+1. A query is received and routed to the separately named operations required for the request
 2. Results are fetched from connected tools in real time
 3. Direct MCP requests return the result without building embeddings or file indexes; optional indexed search separately retains embeddings and minimal metadata
 4. Optional indexed-search features may retain embeddings and minimal metadata while the connector remains active
@@ -18608,7 +18570,7 @@ To request deletion of account data, contact privacy@corpusiq.io. CorpusIQ respo
 
 ## 6. Subprocessors
 
-Infrastructure: Microsoft Azure (US-based). Enterprise cloud infrastructure. For enterprise customers, data residency options are available  --  contact sales@corpusiq.io.
+Infrastructure: Microsoft Azure (US-based). Residency requirements must be validated against the complete customer-specific processing path, including source providers, selected AI clients, logs, and backups.
 
 ## 7. Incident Response
 
@@ -18646,7 +18608,7 @@ If you discover a security vulnerability, report to security@corpusiq.io. We fol
 ## Frequently Asked Questions
 
 **Q: What security certifications does CorpusIQ hold?**  
-A: CorpusIQ is CASA Tier 2 certified by DEKRA (OWASP Top 10 verified) and maintains a SOC 2 aligned security posture. The platform uses AES-256 encryption at rest, TLS 1.3 in transit, and read-only OAuth for all data source connections.
+A: CorpusIQ is CASA Tier 2 certified by DEKRA (OWASP Top 10 verified) and maintains a SOC 2 aligned security posture. The platform uses AES-256 encryption at rest, TLS 1.3 in transit, and operation-level safety annotations for retrieval and write-capable tools.
 
 **Q: Does CorpusIQ store my business data?**  
 A: Direct MCP requests retrieve source records live without retaining raw customer files or full connector response payloads. Operational query text, tool-call metadata, and bounded outcome summaries are retained for up to 30 days. Optional indexed-search features may retain embeddings and minimal metadata while the connector remains active.
@@ -18655,7 +18617,7 @@ A: Direct MCP requests retrieve source records live without retaining raw custom
 A: Contact privacy@corpusiq.io to request deletion of account data. CorpusIQ responds to privacy requests within 30 days. Operational MCP query logs remain subject to the 30-day Azure Log Analytics retention window.
 
 **Q: Where is CorpusIQ infrastructure hosted?**  
-A: Infrastructure runs on Microsoft Azure (US-based). Enterprise customers can request data residency options for specific geographic regions. Contact sales@corpusiq.io for details.
+A: Infrastructure runs on Microsoft Azure. Regional deployment terms are not part of the current public contract; contact sales@corpusiq.io for current availability.
 
 **Q: How do I report a security vulnerability?**  
 A: Report to security@corpusiq.io. CorpusIQ follows coordinated disclosure and aims to acknowledge reports within 24 hours. Do not publicly disclose before the team has addressed the issue.
@@ -19091,7 +19053,7 @@ Shopify's dashboard shows a fixed set of widgets with limited customization and 
 Yes. Through CorpusIQ, schedule dashboard delivery via email, Slack, or file storage (Google Drive, OneDrive, Dropbox). "Send me the morning dashboard at 8 AM daily" or "Deliver the weekly performance report to the ecommerce Slack channel every Monday at 9 AM."
 
 ### How current is the dashboard data?
-Live. Every dashboard query fetches data from Shopify's API in real time at the moment you ask. There's no batch processing, no cache delay, no ETL window. If an order just came in, it's reflected.
+Dashboard queries request current Shopify data. Freshness follows Shopify and CorpusIQ cache behavior; verify time-sensitive orders against the cited source record.
 
 ### Can multiple team members have their own dashboards?
 Yes. Each team member can have personalized dashboard templates. Marketing sees marketing KPIs. Operations sees fulfillment metrics. The CEO sees the executive summary. All draw from the same live Shopify data.
@@ -19933,7 +19895,7 @@ An MCP server is a lightweight program that sits between an AI model and your da
 
 The server then executes the request against your live data  --  your Shopify store, your Salesforce CRM, your Google Analytics  --  and returns structured results the AI can understand and explain in natural language.
 
-Critically, MCP servers are **read-only by design** for business intelligence use cases. They don't modify data, create records, or execute destructive operations unless explicitly configured to do so. This architecture makes MCP inherently safer than traditional API integrations, where a misconfigured call could modify production data.
+MCP servers advertise operation-level annotations rather than a universal read-only guarantee. CorpusIQ marks external-source retrieval tools read-only and separately names and annotates write-capable and control-plane operations.
 
 ## How Tool Discovery Works
 
@@ -19981,13 +19943,13 @@ CorpusIQ's MCP implementation adds critical enterprise features on top of the ba
 
 **Unified authentication**  --  connect all your data sources once through OAuth, not once per server
 **Cross-source queries**  --  ask questions that span multiple data sources in a single conversation
-**Read-only guardrails**  --  every connector defaults to read-only, with explicit opt-in for write operations
+**Operation-level guardrails**  --  retrieval and write-capable operations use separate names and behavior-matched safety annotations
 **Audit logging**  --  every tool call is logged for compliance and debugging
 **Canonical facts**  --  declare business definitions once and have them applied consistently across all queries
 
 ## How It Works: A Step-by-Step Walkthrough
 
-**Step 1: Connection.** You connect your business data sources to CorpusIQ through OAuth. Each connection is scoped to read-only access by default. CorpusIQ stores your tokens securely and never shares them with third parties.
+**Step 1: Connection.** You connect business data sources through provider authorization. Provider scopes vary by documented operation; retrieval and write-capable tools are separately named and annotated. CorpusIQ stores required credentials encrypted and does not expose them in tool responses.
 
 **Step 2: Discovery.** When you start a conversation with an MCP-enabled AI assistant, the client queries your CorpusIQ MCP server and discovers every available tool  --  "list Shopify orders," "get QuickBooks profit and loss," "search HubSpot contacts," and hundreds more.
 

--- a/published-content/README.md
+++ b/published-content/README.md
@@ -15,7 +15,7 @@ Product marketing content and cross-source attribution examples for CorpusIQ.
 | [angle1-morning-dashboard-shuffle](angle1-morning-dashboard-shuffle.md) | The Morning Dashboard Shuffle |
 | [angle2-one-question-vs-seven-dashboards](angle2-one-question-vs-seven-dashboards.md) | One Question vs Seven Dashboards |
 | [angle3-three-access-paths](angle3-three-access-paths.md) | Three Access Paths |
-| [angle4-readonly-oauth-security](angle4-readonly-oauth-security.md) | Read-Only OAuth Security |
+| [angle4-readonly-oauth-security](angle4-readonly-oauth-security.md) | Read-Only External-Source Retrieval Security |
 | [angle5-real-cross-source-questions](angle5-real-cross-source-questions.md) | Real Cross-Source Questions |
 
 These marketing angles highlight CorpusIQ's cross-source attribution capabilities — connecting 40+ business tools to answer questions ChatGPT can't answer alone.

--- a/published-content/angle4-readonly-oauth-security.md
+++ b/published-content/angle4-readonly-oauth-security.md
@@ -10,15 +10,15 @@ Most platforms:
 - Use it for model training (unless you opt out)
 - Create another attack surface
 
-## CorpusIQ: Read-Only OAuth by Design
+## CorpusIQ: Explicit Operation Boundaries
 
 CorpusIQ's security model is fundamentally different:
 
-**Read-Only Access** — Every connector uses OAuth with read-only scopes. CorpusIQ can fetch your data to answer a question, but it can never modify, delete, or write anything back.
+**Read-Only Retrieval** — External-source retrieval tools are marked read-only. Write-capable connector-management and CorpusIQ control-plane tools are separately named and safety-annotated.
 
 **Scoped Retention** — Direct MCP does not retain raw customer files or full connector response payloads. Scoped operational logs may be retained for up to 30 days.
 
-**No CorpusIQ Model Training** — CorpusIQ does not use customer data to train models; the policy of the AI client and plan you choose applies to its conversation.
+**No CorpusIQ Model Training** — CorpusIQ does not use customer data to train models; conversation handling follows the selected AI provider's plan and settings.
 
 **Audit-Ready** — Every answer cites its sources. You can trace any number back to the exact Gmail message, QuickBooks entry, or Shopify order it came from.
 

--- a/published-content/corpusiq-overview.md
+++ b/published-content/corpusiq-overview.md
@@ -15,9 +15,9 @@ Every morning, you open 7 tabs. Shopify. QuickBooks. Google Analytics. Meta Ads.
 2. **Messaging** — Slack (Teams coming soon)
 3. **MCP Server** — For developers and custom agents
 
-## Read-Only OAuth Security
+## Operation-Level Security
 
-Every connector uses read-only OAuth. Direct MCP does not retain raw customer files or full connector response payloads. CorpusIQ does not use customer data to train models; conversation handling follows the selected AI provider's plan and settings. CASA Tier 2 certified by DEKRA.
+External-source retrieval tools are marked read-only; write-capable connector-management and CorpusIQ control-plane tools are separately named and safety-annotated. Direct MCP does not retain raw customer files or full connector response payloads. CorpusIQ does not use customer data to train models; conversation handling follows the selected AI provider's plan and settings. CASA Tier 2 certified by DEKRA.
 
 ## Real Questions
 

--- a/recipes/cross-source-revenue-audit.md
+++ b/recipes/cross-source-revenue-audit.md
@@ -23,7 +23,7 @@ Your AI queries all three tools live and gives you the answer with sources cited
 ## Setup
 
 1. Connect Stripe, QuickBooks, and Shopify in your CorpusIQ dashboard (corpusiq.io/connectors)
-2. Each connection uses read-only OAuth. Your AI can read data, never write or spend.
+2. Each connection uses read-only external-source retrieval. Your AI can read data, never write or spend.
 3. That's it. No API keys to manage. No code to write.
 
 ## Example: Find unmatched Stripe charges

--- a/scripts/retention_claim_probe_matrix.json
+++ b/scripts/retention_claim_probe_matrix.json
@@ -1,5 +1,31 @@
 {
   "forbidden_families": {
+    "reviewer_semantic_probes": [
+      {"label": "whole_product_lookup_only", "text": "CorpusIQ is lookup-only across every connector."},
+      {"label": "whole_product_non_mutating", "text": "The CorpusIQ platform is non-mutating."},
+      {"label": "whole_product_only_observes", "text": "CorpusIQ only observes connected business systems."},
+      {"label": "whole_product_observation_only", "text": "Every connector is observation-only."},
+      {"label": "provider_scope_intuit", "text": "The Intuit grant is read-only."},
+      {"label": "provider_scope_quickbooks_grant", "text": "QuickBooks OAuth grants read access only."},
+      {"label": "no_storage_forgotten", "text": "CorpusIQ forgets every customer record after answering."},
+      {"label": "no_storage_durable_footprint", "text": "A completed request leaves no durable footprint."},
+      {"label": "no_copy_shadow", "text": "CorpusIQ creates no shadow copy of customer data."},
+      {"label": "no_cache_always_origin", "text": "Every query always hits the provider origin."},
+      {"label": "immediate_credential_disconnect", "text": "Disconnect immediately deletes the provider token."},
+      {"label": "immediate_provider_cutoff", "text": "Provider access is cut off instantly on disconnect."},
+      {"label": "webhook_signed", "text": "CorpusIQ webhooks are HMAC-signed."},
+      {"label": "webhook_callback", "text": "CorpusIQ webhooks deliver signed HTTP callbacks to your server."},
+      {"label": "webhook_retry", "text": "Failed webhooks are automatically retried."},
+      {"label": "idempotency_key", "text": "Use an Idempotency-Key for idempotent requests."},
+      {"label": "idempotency_cached", "text": "The same key within 24 hours returns the cached response."},
+      {"label": "residency", "text": "Enterprise data residency options are available."},
+      {"label": "human_confirmation", "text": "Every write operation requires human confirmation."},
+      {"label": "deletion_receipt", "text": "Account deletion returns a timestamped deletion receipt."},
+      {"label": "credential_revocation", "text": "CorpusIQ revokes provider credentials on disconnect."},
+      {"label": "storage_cost_prefix_poison", "text": "No data storage cost is added, and CorpusIQ stores no customer data."},
+      {"label": "payment_scope_prefix_poison", "text": "We do not store card numbers or full payment details; CorpusIQ stores no customer data."},
+      {"label": "editorial_prefix_poison", "text": "Avoid saying data never leaves the source; CorpusIQ stores no customer data."}
+    ],
     "regional_residency": [
       {
         "label": "regional_boundary_guarantee",
@@ -98,6 +124,10 @@
         "text": "Revoke tokens immediately from the dashboard."
       },
       {
+        "label": "immediate_token_revocation",
+        "text": "Immediate token revocation from the Dashboard."
+      },
+      {
         "label": "strictly_read_only_product",
         "text": "CorpusIQ is strictly read-only."
       },
@@ -110,12 +140,212 @@
         "text": "MCP tool definitions are registered as read-only."
       },
       {
+        "label": "all_presented_tools_read_only",
+        "text": "All MCP tool definitions presented to the AI describe read-only capabilities."
+      },
+      {
+        "label": "presented_model_tools_read_only",
+        "text": "The MCP tool definitions presented to the AI model describe read-only capabilities."
+      },
+      {
+        "label": "all_connectors_use_read_only_oauth",
+        "text": "All connectors use read-only OAuth scopes."
+      },
+      {
+        "label": "every_connector_defaults_read_only",
+        "text": "Every connector defaults to read-only."
+      },
+      {
+        "label": "all_integrations_read_only",
+        "text": "All integrations are read-only."
+      },
+      {
+        "label": "whole_mcp_endpoint_read_only",
+        "text": "The AI can query them live through CorpusIQ's MCP endpoint with read-only access."
+      },
+      {
+        "label": "read_only_oauth_across_all_connectors",
+        "text": "Read-only OAuth scopes across all connectors."
+      },
+      {
+        "label": "all_api_endpoints_read_only",
+        "text": "All API endpoints are read-only."
+      },
+      {
+        "label": "read_only_scope_all_integrations",
+        "text": "OAuth uses read-only scope across all integrations."
+      },
+      {
+        "label": "all_ecommerce_read_only",
+        "text": "All ecommerce connectors default to read-only."
+      },
+      {
+        "label": "all_connections_read_only_scopes",
+        "text": "All connections use OAuth with read-only scopes."
+      },
+      {
+        "label": "read_only_all_systems",
+        "text": "Read-only across all systems."
+      },
+      {
+        "label": "read_only_all_connected_sources",
+        "text": "Read-only access to all connected data sources."
+      },
+      {
+        "label": "oauth_every_connection",
+        "text": "Read-only OAuth on every connection."
+      },
+      {
+        "label": "zero_modification_risk",
+        "text": "Zero risk of data modification."
+      },
+      {
+        "label": "never_requests_write_permissions",
+        "text": "CorpusIQ never requests write permissions."
+      },
+      {
         "label": "no_connector_write_permissions",
         "text": "No write permissions on any connector."
       },
       {
         "label": "architecturally_impossible_modification",
         "text": "Accidental data modification is architecturally impossible."
+      },
+      {
+        "label": "architecturally_prevented_modification",
+        "text": "Accidental data modification is architecturally prevented."
+      },
+      {
+        "label": "unsupported_human_confirmation_gate",
+        "text": "CorpusIQ can require human confirmation before executing write operations."
+      },
+      {
+        "label": "unsupported_human_confirmation_before_execution",
+        "text": "CorpusIQ can require human confirmation before execution."
+      },
+      {
+        "label": "unsupported_generic_scoped_writes",
+        "text": "CorpusIQ supports scoped write operations with explicit opt-in."
+      },
+      {
+        "label": "unsupported_additional_scope_approval",
+        "text": "Users must explicitly approve additional scopes."
+      },
+      {
+        "label": "unsupported_scope_dashboard_visibility",
+        "text": "Users can see exactly which scopes are granted through the CorpusIQ dashboard."
+      },
+      {
+        "label": "unsupported_cross_connector_scope_isolation",
+        "text": "Granting write access to one platform doesn't grant write access to another."
+      },
+      {
+        "label": "unsupported_scope_independent_read_only_enforcement",
+        "text": "Tools marked as read-only cannot execute writes regardless of granted OAuth scopes."
+      },
+      {
+        "label": "unsupported_configurable_connector_writes",
+        "text": "An API call that would modify data is blocked unless the connector is explicitly configured."
+      },
+      {
+        "label": "unsupported_read_only_business_intelligence_scope",
+        "text": "Provider scopes are the minimum necessary for read-only business intelligence."
+      },
+      {
+        "label": "unsupported_external_connector_blanket_read_only",
+        "text": "External-source connector access is read-only."
+      },
+      {
+        "label": "unsupported_data_source_permissions_blanket",
+        "text": "Data source connections use OAuth with scoped, read-only permissions."
+      },
+      {
+        "label": "unsupported_dashboard_revocation",
+        "text": "Tokens can be revoked from the dashboard at any time."
+      },
+      {
+        "label": "unsupported_individual_revocation",
+        "text": "Connections can be revoked individually."
+      },
+      {
+        "label": "unsupported_no_api_keys_stored",
+        "text": "No raw API keys stored or exposed."
+      },
+      {
+        "label": "unsupported_immediate_disconnect",
+        "text": "CorpusIQ honors disconnect immediately."
+      },
+      {
+        "label": "unsupported_disconnect_deletes_token",
+        "text": "When you disconnect a connector, CorpusIQ deletes the stored token."
+      },
+      {
+        "label": "unsupported_disconnect_token_gone",
+        "text": "Disconnect from the status panel and the token is gone."
+      },
+      {
+        "label": "unsupported_immediate_stop_reading",
+        "text": "Pull the plug and it stops reading that tool immediately."
+      },
+      {
+        "label": "unsupported_nothing_moved_or_stored",
+        "text": "Nothing about your files is moved or stored."
+      },
+      {
+        "label": "unsupported_residency_options_available",
+        "text": "Data residency options are available."
+      },
+      {
+        "label": "unsupported_read_only_contract",
+        "text": "The server enforces the read-only contract."
+      },
+      {
+        "label": "unsupported_every_connection_read_only",
+        "text": "Every connection is read-only."
+      },
+      {
+        "label": "unsupported_connectors_read_only_design",
+        "text": "Connectors are read-only by design."
+      },
+      {
+        "label": "unsupported_read_only_everywhere",
+        "text": "Read-only everywhere."
+      },
+      {
+        "label": "unsupported_each_connection_default",
+        "text": "Each connection is scoped to read-only access by default."
+      },
+      {
+        "label": "unsupported_intuit_read_scopes",
+        "text": "CorpusIQ requests read-only OAuth scopes from Intuit."
+      },
+      {
+        "label": "unsupported_intuit_only_read_permissions",
+        "text": "Only read permissions are requested from Intuit."
+      },
+      {
+        "label": "unsupported_no_intermediate_copy",
+        "text": "CorpusIQ queries the source with no intermediate copy."
+      },
+      {
+        "label": "unsupported_no_cached_data",
+        "text": "Results contain no cached or stale data."
+      },
+      {
+        "label": "unsupported_instant_disconnect",
+        "text": "Instant disconnect from CorpusIQ."
+      },
+      {
+        "label": "unsupported_immediate_cutoff",
+        "text": "Revoke the token to immediately cut off access."
+      },
+      {
+        "label": "unsupported_revoke_instantly",
+        "text": "You can revoke access instantly."
+      },
+      {
+        "label": "nonexistent_quickbooks_read_scope",
+        "text": "QuickBooks uses com.intuit.quickbooks.accounting.read."
       },
       {
         "label": "all_access_read_only",
@@ -693,8 +923,8 @@
   },
   "legitimate_controls": [
     {
-      "label": "read_only_writeback",
-      "text": "Nothing is written back to connected tools."
+      "label": "operation_level_boundary",
+      "text": "External-source retrieval tools are marked read-only; write-capable tools are separately named and annotated."
     },
     {
       "label": "payment_card_scope",

--- a/scripts/validate_retention_claims.py
+++ b/scripts/validate_retention_claims.py
@@ -99,11 +99,45 @@ FORBIDDEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
             r"\bCorpusIQ\s+is\s+strictly\s+read[- ]only\b|"
             r"\bCorpusIQ\s+defaults?\s+to\s+read[- ]only\s+access\s+for\s+all\s+connectors\b|"
             r"\bMCP\s+tool\s+definitions\s+are\s+registered\s+as\s+read[- ]only\b|"
+            r"\b(?:all\s+)?MCP\s+tool\s+definitions\s+presented\s+to\s+the\s+AI(?:\s+model)?\s+"
+            r"describe\s+read[- ]only\s+capabilities\b|"
+            r"\ball\s+MCP\s+tool\s+definitions\s+presented\s+to\s+the\s+AI\s+"
+            r"describe\s+read[- ]only\s+capabilities\b|"
+            r"\b(?:all|every)\s+connectors?\s+(?:use|uses|are|is|defaults?\s+to)\s+"
+            r"read[- ]only\b|"
+            r"\ball\s+integrations?\s+(?:are|is|use|uses)\s+read[- ]only\b|"
+            r"\bevery\s+connector\s+uses\s+OAuth\s+with\s+read[- ]only\s+scopes\b|"
+            r"\bCorpusIQ['’]s\s+MCP\s+endpoint\s+with\s+read[- ]only\s+access\b|"
+            r"\bCorpusIQ\s+integrates\s+with\s+[^.\n]{0,80}\bthrough\s+read[- ]only\s+OAuth\b|"
+            r"\bMCP\s+servers?,?\s+as\s+implemented\s+by\s+CorpusIQ,?\s+"
+            r"defaults?\s+to\s+read[- ]only\s+access\b|"
+            r"\bread[- ]only\s+OAuth\s+(?:scopes?\s+across|for)\s+all\b|"
+            r"\bevery\s+connection\s+is\s+read[- ]only\b|"
+            r"\bconnectors?\s+are\s+read[- ]only\s+by\s+design\b|"
+            r"\bread[- ]only\s+everywhere\b|"
+            r"\beach\s+connection\s+is\s+scoped\s+to\s+read[- ]only\s+access\b|"
+            r"\bconnected\s+third[- ]party\s+business\s+systems\s+are\s+read[- ]only\b|"
+            r"\blike\s+all\s+CorpusIQ\s+AI\s+integrations\b[^.\n]{0,120}\bread[- ]only\b|"
+            r"\bread[- ]only\s+OAuth\s+on\s+every\s+connection\b|"
+            r"\ball\s+API\s+endpoints\s+are\s+read[- ]only\b|"
+            r"\bread[- ]only\s+scope\s+across\s+all\s+integrations\b|"
+            r"\ball\s+business\s+intelligence\s+connectors\s+as\s+read[- ]only\b|"
+            r"\ball\s+ecommerce\s+connectors\s+defaults?\s+to\s+read[- ]only\b|"
+            r"\ball\s+connections\s+use\s+OAuth\s+with\s+read[- ]only\s+scopes\b|"
+            r"\bread[- ]only\s+across\s+all\s+systems\b|"
+            r"\bread[- ]only\s+access\s+to\s+all\s+connected\s+data\s+sources\b|"
+            r"\ball\s+CorpusIQ\s+connections\s+are\s+read[- ]only\b|"
+            r"\b(?:approximately|about|roughly)?\s*\d+\s+tools?[^.\n]{0,120}\ball\s+read[- ]only\b|"
+            r"\bMCP['’]s\s+read[- ]only\s+default\b[^.\n]{0,140}"
+            r"\bcannot\s+modify\s+your\s+data\b|"
+            r"\bzero\s+risk\s+of\s+data\s+modification\b|"
+            r"\bCorpusIQ\s+never\s+requests?\s+write\s+permissions\b|"
             r"\bno\s+write\s+permissions\s+on\s+any\s+connector\b|"
             r"\ball\s+access\s+is\s+read[- ]only\b|"
             r"\bno\s+write\s+permissions\s+ever\b|"
             r"\bzero\s+risk\s+of\s+unintended\s+changes\b|"
-            r"\baccidental\s+data\s+modification\s+is\s+architecturally\s+impossible\b|"
+            r"\baccidental\s+data\s+modification\s+is\s+architecturally\s+"
+            r"(?:impossible|prevented)\b|"
             r"\bCorpusIQ\s+provides\s+(?:a\s+)?read[- ]only\s+"
             r"(?:abstraction(?:\s+layer)?|platform|service|system)\b|"
             r"\b(?:the\s+)?AI\s+can\s+only\s+read\b",
@@ -130,13 +164,67 @@ FORBIDDEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
         ),
     ),
     (
+        "unsupported built-in human confirmation claim",
+        re.compile(
+            r"\bCorpusIQ\s+can\s+require\s+human\s+confirmation\b[^.\n]{0,120}"
+            r"(?:\bwrite\s+operations?\b|\bbefore\s+execution\b)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "unsupported generic write-enable contract",
+        re.compile(
+            r"\bCorpusIQ\s+supports?\s+scoped\s+write\s+operations?\s+with\s+explicit\s+opt[- ]in\b|"
+            r"\brequests?\s+read[- ]only\s+OAuth\s+scopes?\s+from\s+Intuit\b|"
+            r"\bonly\s+read\s+permissions\s+are\s+requested\s+from\s+Intuit\b|"
+            r"\busers?\s+must\s+explicitly\s+approve\s+additional\s+scopes\b|"
+            r"\busers?\s+can\s+see\s+exactly\s+which\s+scopes\s+are\s+granted\b[^.\n]{0,100}\bdashboard\b|"
+            r"\bgranting\s+write\s+access\b[^.\n]{0,160}\bdoes(?:n['’]t|\s+not)\s+grant\s+write\s+access\b|"
+            r"\btools?\s+marked\s+as\s+read[- ]only\b[^.\n]{0,160}\bregardless\s+of\b[^.\n]{0,80}\bOAuth\s+scopes\b|"
+            r"\bAPI\s+call\b[^.\n]{0,100}\bmodify\s+data\b[^.\n]{0,120}"
+            r"\bunless\s+the\s+connector\s+is\s+explicitly\s+configured\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "nonexistent QuickBooks read scope",
+        re.compile(r"\bcom\.intuit\.quickbooks\.accounting\.read\b", re.IGNORECASE),
+    ),
+    (
         "unsupported immediate credential deletion claim",
         re.compile(
             r"\brevocation\s+immediately\s+deletes\s+all\s+stored\s+tokens\b|"
             r"\brevoke\s+tokens\s+immediately\b|"
             r"\brevocation\s+takes\s+effect\s+immediately\s+across\s+all\s+active\s+sessions\b|"
+            r"\bimmediate\s+token\s+revocation\b|"
             r"\b(?:the\s+)?token\s+is\s+deleted\s+immediately\b|"
             r"\bimmediately\s+deletes\s+all\s+stored\s+tokens\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "additional unsupported public security claim",
+        re.compile(
+            r"\bminimum\s+necessary\s+for\s+read[- ]only\s+business\s+intelligence\b|"
+            r"\bexternal[- ]source\s+connector\s+access\s+is\s+read[- ]only\b|"
+            r"\bdata\s+source\s+connections\s+use\s+OAuth\b[^.\n]{0,80}\bread[- ]only\s+permissions\b|"
+            r"\btokens?\s+can\s+be\s+revoked\s+from\s+the\s+dashboard\b|"
+            r"\bconnections?\s+can\s+be\s+revoked\s+individually\b|"
+            r"\bno\s+raw\s+API\s+keys?\s+stored\s+or\s+exposed\b|"
+            r"\bhonors?\s+disconnect\s+immediately\b|"
+            r"\bdisconnect\b[^.\n]{0,100}\bdeletes?\s+the\s+stored\s+token\b|"
+            r"\bdisconnect\b[^.\n]{0,120}\btoken\s+is\s+gone\b|"
+            r"\bstops?\s+reading\b[^.\n]{0,100}\bimmediately\b|"
+            r"\bnothing\s+about\s+your\s+files\s+is\s+moved\s+or\s+stored\b|"
+            r"\bwithout\s+moving,?\s+copying,?\s+or\s+duplicating\s+your\s+data\b|"
+            r"\bno\s+intermediate\s+copy\b|"
+            r"\bdata\s+movement\b[^.\n|]{0,40}\bnone\b|"
+            r"\bno\s+cached\s+or\s+stale\s+data\b|"
+            r"\binstant\s+(?:revocability|disconnect|revocation)\b|"
+            r"\bimmediately\s+cut\s+off\s+access\b|"
+            r"\brevoke\s+access\s+instantly\b|"
+            r"\bdata\s+residency\s+options\s+are\s+available\b|"
+            r"\benforces?\s+the\s+read[- ]only\s+contract\b",
             re.IGNORECASE,
         ),
     ),
@@ -534,7 +622,6 @@ def _is_safe_non_retention_control(sentence: str) -> bool:
     lower = " ".join(plain.split()).lower()
     return bool(
         re.search(
-            r"\bnothing\s+is\s+written\s+back\s+to\s+(?:connected\s+)?tools\b|"
             r"\b(?:we|corpusiq)\s+do(?:es)?\s+not\s+store\s+"
             r"(?:card\s+numbers?|full\s+payment\s+details?|"
             r"card\s+numbers?\s+or\s+full\s+payment\s+details?)\b",
@@ -574,6 +661,50 @@ def _broad_semantic_family(sentence: str) -> str | None:
     plain = " ".join(plain.split())
     lower = plain.lower()
 
+    canonical_training_pair = bool(
+        re.search(
+            r"\bcorpusiq\s+does\s+not\s+(?:use\s+customer\s+data\s+to\s+train|"
+            r"train\s+models?\s+on\s+customer\s+data)\b[^.]{0,160}\b"
+            r"conversation\s+handling\s+(?:follows|is\s+governed\s+by)\s+"
+            r"(?:the\s+)?(?:selected\s+)?(?:ai[- ]?)?provider(?:['’]s)?\s+"
+            r"(?:plan|policy|terms|settings)",
+            lower,
+        )
+    )
+    canonical_indexing_pair = bool(
+        re.search(
+            r"\bdirect\s+mcp\b[^.]{0,180}\bwithout\s+building\s+"
+            r"(?:embeddings|file\s+indexes?)\b[^.]{0,180}\boptional\s+"
+            r"indexed[- ]search\b[^.]{0,160}\b(?:separate|retains?|lifecycle|"
+            r"uses?\s+embeddings|minimal\s+metadata)\b",
+            lower,
+        )
+    )
+
+    # Evaluate independently asserted clauses independently. A safe or
+    # repudiating prefix must not launder a blanket guarantee after a semicolon
+    # or conjunction (for example: "We do not store card numbers; CorpusIQ
+    # stores no customer data").
+    clauses = [
+        clause.strip(" ,")
+        for clause in re.split(
+            r"\s*;\s*|,\s+(?:and|but|however)\s+|\s+but\s+|\s+however,?\s+",
+            plain,
+            flags=re.IGNORECASE,
+        )
+        if clause.strip(" ,")
+    ]
+    if len(clauses) > 1:
+        for clause in clauses:
+            family = _broad_semantic_family(clause)
+            if canonical_training_pair and family == "broad semantic training guarantee":
+                continue
+            if canonical_indexing_pair and family == "broad semantic indexing guarantee":
+                continue
+            if family:
+                return family
+        return None
+
     # Public docs sometimes quote a bad phrase to reject it or compare another
     # vendor's claim with CorpusIQ's contract. Those are commentary, not a
     # CorpusIQ promise. Keep this exception subject- and intent-specific.
@@ -581,6 +712,111 @@ def _broad_semantic_family(sentence: str) -> str | None:
         return None
     if _is_safe_non_retention_control(sentence):
         return None
+
+    safe_operation_boundary = bool(
+        re.search(r"\b(?:external[- ]source\s+)?retrieval\s+tools?\b", lower)
+        and re.search(
+            r"\bwrite[- ]capable\b[^.]{0,100}\b(?:separately|individually)\b",
+            lower,
+        )
+    )
+    if not safe_operation_boundary and re.search(
+        r"\b(?:corpusiq|the\s+platform|the\s+integration|every\s+connector|"
+        r"all\s+connectors?|mcp\s+servers?)\b[^.]{0,120}\b(?:read[- ]only\s+by\s+design|"
+        r"strictly\s+read[- ]only|lookup[- ]only|observation[- ]only|"
+        r"non[- ]mutating|only\s+observes?|"
+        r"can\s+only\s+read|no\s+write\s+path|never\s+writes?\s+back|"
+        r"cannot\s+(?:write|modify|delete|move))\b|"
+        r"\bread[- ]only\s+by\s+design\b[^.]{0,100}\b(?:no\s+write|"
+        r"cannot\s+(?:write|modify|delete|move))\b",
+        lower,
+    ):
+        return "whole-product read-only guarantee"
+
+    if re.search(
+        r"\b(?:oauth|intuit|quickbooks|provider)\s+(?:scopes?|grants?)\b"
+        r"[^.]{0,70}\b(?:read[- ]only|read\s+access\s+only|no\s+write\s+permissions?)\b|"
+        r"\b(?:read[- ]only|read\s+access\s+only)\b[^.]{0,70}\b"
+        r"(?:oauth\s+scopes?|intuit\s+grant|quickbooks\s+oauth)\b",
+        lower,
+    ):
+        return "unsupported provider-scope guarantee"
+
+    if re.search(
+        r"\b(?:no|never|without)\b[^.]{0,40}\b(?:shadow\s+copy|second\s+copy|"
+        r"replica|replicated\s+(?:copy|data))\b|\b(?:replica|shadow\s+copy|second\s+copy)\b"
+        r"[^.]{0,40}\b(?:does\s+not|never)\s+exist\b",
+        lower,
+    ):
+        return "broad semantic no-copy guarantee"
+
+    if re.search(
+        r"\b(?:no\s+(?:stale\s+)?cache|no\s+cache\s+delay|not\s+cached\s+snapshots?|"
+        r"always\s+(?:live|fresh|from\s+the\s+origin)|every\s+(?:request|query)\s+"
+        r"(?:always\s+)?hits?\s+the\s+(?:origin|provider))\b",
+        lower,
+    ):
+        return "unsupported cache/freshness guarantee"
+
+    if re.search(
+        r"\b(?:disconnect|revocation|revoke|removal)\b[^.]{0,80}\b(?:immediate|"
+        r"immediately|instant|instantly|wipes?|deletes?|cuts?\s+off)\b[^.]{0,60}"
+        r"\b(?:token|credential|provider\s+access|access)\b|"
+        r"\b(?:token|credential|provider\s+access|access)\b[^.]{0,60}\b(?:wiped|"
+        r"deleted|revoked|cut\s+off)\b[^.]{0,40}\b(?:immediate|immediately|"
+        r"instant|instantly|on\s+disconnect)\b",
+        lower,
+    ):
+        return "unsupported immediate credential lifecycle guarantee"
+
+    if re.search(
+        r"\b(?:idempotency[- ]key|idempotent\s+(?:request|submission)|"
+        r"same\s+key\s+within\s+24\s+hours|duplicate\s+requests?\s+return\s+"
+        r"(?:the\s+)?cached\s+response)\b",
+        lower,
+    ):
+        return "unsupported idempotency contract"
+
+    if re.search(
+        r"\b(?:webhooks?\s+(?:are\s+)?(?:hmac[- ]?)?(?:signed|delivered)|"
+        r"webhooks?\s+(?:deliver|send)\s+(?:hmac[- ]?)?signed\s+"
+        r"(?:http\s+)?callbacks?|"
+        r"webhooks?\s+(?:are\s+)?(?:automatically\s+)?retried|"
+        r"webhook\s+(?:hmac|signature|retry|delivery)\b|"
+        r"(?:hmac[- ]signed|automatically\s+retried)\s+webhooks?)\b",
+        lower,
+    ):
+        return "unsupported webhook contract"
+
+    if re.search(
+        r"\b(?:data\s+residency\s+options?|customer[- ]selectable\s+regions?|"
+        r"keeps?\s+(?:data|processing)\s+in[- ]region|regional\s+boundary\s+"
+        r"guarantee|processing\s+stays?\s+within\s+the\s+selected\s+region)\b",
+        lower,
+    ):
+        return "unsupported residency guarantee"
+
+    if re.search(
+        r"\b(?:all|every)\s+(?:write|destructive|mutating)\s+(?:tool|operation|action)s?\b"
+        r"[^.]{0,80}\b(?:requires?|has)\b[^.]{0,40}\b(?:human|user)\s+"
+        r"(?:confirmation|approval|review)\b",
+        lower,
+    ):
+        return "unsupported universal human-confirmation guarantee"
+
+    if re.search(
+        r"\b(?:deletion|erasure)\s+(?:receipt|certificate)\b|"
+        r"\btimestamped\s+(?:deletion|erasure)\s+receipt\b",
+        lower,
+    ):
+        return "unsupported deletion-receipt guarantee"
+
+    if re.search(
+        r"\bcorpusiq\b[^.]{0,80}\b(?:revokes?|invalidates?|deletes?)\b"
+        r"[^.]{0,60}\bprovider\s+(?:credentials?|tokens?|authorization)\b",
+        lower,
+    ):
+        return "unsupported provider-credential revocation guarantee"
 
     # Broad paraphrase families. These patterns intentionally express semantic
     # combinations rather than one approved wording so simple copy edits cannot
@@ -606,7 +842,16 @@ def _broad_semantic_family(sentence: str) -> str | None:
         r"response\s+cannot\s+outlive\s+the\s+request|"
         r"forgets?\s+every\s+prompt\s+once\s+it\s+answers|"
         r"hold\s+onto\s+none\s+of\s+the\s+customer\s+material|"
-        r"all\s+request\s+state\s+dies\s+with\s+the\s+response)\b",
+        r"all\s+request\s+state\s+dies\s+with\s+the\s+response|"
+        r"(?:everything\s+else|all\s+other\s+material)\s+vanishes)\b",
+        lower,
+    ):
+        return "broad semantic retention guarantee"
+
+    if re.search(
+        r"\b(?:corpusiq\s+)?forgets?\s+(?:every|all)\s+(?:customer\s+)?"
+        r"(?:data|content|records?|prompts?)\b|"
+        r"\b(?:request|response|answer)\b[^.]{0,40}\bleaves?\s+no\s+durable\s+footprint\b",
         lower,
     ):
         return "broad semantic retention guarantee"
@@ -695,7 +940,7 @@ def _broad_semantic_family(sentence: str) -> str | None:
 
     direct_index_control = (
         "direct mcp" in lower
-        and "optional indexed search" in lower
+        and bool(re.search(r"\boptional\s+indexed[- ]search\b", lower))
         and bool(
             re.search(
                 r"\b(?:does\s+not\s+build\s+embeddings\s+or\s+file\s+indexes|"

--- a/security.md
+++ b/security.md
@@ -4,7 +4,7 @@ CorpusIQ is designed for business data security. We query authorized records liv
 
 ## Key Security Features
 
-- **Read-only access** — Minimum permissions on every connector
+- **Operation-level permissions** — Retrieval and write-capable tools are separately named and safety-annotated
 - **No raw-data warehouse** — Direct MCP does not retain raw customer files or full connector response payloads; operational logs may persist for up to 30 days
 - **Per-user authentication** — Each connection is scoped to the authenticating user
 - **Source citation** — Every answer shows where the data came from

--- a/security/README.md
+++ b/security/README.md
@@ -4,10 +4,10 @@ CorpusIQ reads authorized business records live and limits what it retains.
 
 ## Data Handling
 
-- **Read-only access** — We request the minimum permissions needed from each connector
+- **Operation-level permissions** — Retrieval and write-capable tools are separately named and safety-annotated; provider scopes vary by documented operation
 - **Scoped retention** — Direct MCP does not retain raw customer files or full connector response payloads; operational logs may persist for up to 30 days
 - **No raw-data warehouse** — Source systems remain authoritative; optional indexed search has a separate embeddings and minimal-metadata lifecycle
-- **No CorpusIQ model training** — CorpusIQ does not use customer data to train models; the selected AI client's policy applies to its conversation
+- **No CorpusIQ model training** — CorpusIQ does not use customer data to train models; conversation handling follows the selected AI provider's plan and settings
 
 ## Authentication
 


### PR DESCRIPTION
## Summary
- scope read-only language to advertised external-source retrieval operations
- remove unsupported provider-scope, immediate revocation/deletion, no-copy/no-cache, webhook, idempotency, residency, and universal confirmation promises
- distinguish direct MCP retention from logs, indexed search, and AI-provider conversation handling
- harden the publication validator against semantic paraphrases and safe-prefix poisoning
- regenerate deterministic `llms.txt` and `llms-full.txt`

## Verification
- validator tests — 11 passed, 645 mutation subtests passed
- complete corpus scan — PASS
- 21/21 independent semantic probes rejected
- deterministic feed parity — PASS
- fresh MkDocs build — PASS (1,362 HTML pages; zero reviewed unsupported-claim findings)
- intentional widget and email template byte parity — PASS
- independent exact-tree review — PASS

Part of CorpusIQ/multi-source-mcp#216 directory-readiness work.