### PR TITLE
Update the zopnight entry to ZopDev MCP

### DIFF
--- a/hermes/mcp/servers/external/index.md
+++ b/hermes/mcp/servers/external/index.md
@@ -2377,8 +2377,8 @@ Read-only investment portfolio access via MCP  --  holdings, performance metrics
 ### PubFi MCP ★ New (June 26)
 Route crypto data needs through PubFi capability and gateway tools. MCP-native crypto data orchestration for AI agents. Essential for operators managing multi-chain crypto data workflows.
 
-### zopnight ★ New (June 26)
-Query and govern your AWS, GCP & Azure cloud estate (and AI runtimes like Bedrock & Vertex AI) from Claude Code or Cursor. Surfaces waste, cost, ownership, and 400+ audit findings across 200+ resource types. Essential for FinOps operators managing multi-cloud infrastructure.
+### ZopDev MCP ★ New (June 26)
+Query and govern your AWS, Azure, GCP, Databricks & Snowflake estate (and AI runtimes like Bedrock & Vertex AI) from Claude Code or Cursor. 263 tools (155 read, 108 write) across cost, inventory, schedules, recommendations, budgets and governance; read-only by default with optional scoped writes. Surfaces waste, cost, ownership, and 400+ audit findings across 200+ resource types. Essential for FinOps operators managing multi-cloud infrastructure.
 
 ### Opencloudcosts ★ New (June 28)
 Anchor AI FinOps to real, live cloud pricing. Multi-cloud MCP server for AWS, GCP & Azure - public list prices AND enterprise negotiated rates (Reserved Instances, Savings Plans, CUDs, EDPs). No credentials needed to query pricing data. Essential for FinOps operators who need AI agents to reason about cloud costs with real pricing data.


### PR DESCRIPTION
**ZopDev MCP**: cloud cost and infrastructure governance across AWS, Azure, GCP, Databricks and Snowflake. 263 tools (155 read, 108 write) covering cost, resources, schedules, recommendations, budgets, governance and diagnostics over a hosted remote MCP endpoint. Read-only by default, with optional scoped writes.

- server link — `https://api.zop.dev/mcp-server`
- learn doc — https://zop.dev/learn/mcp-server?utm_source=corpusiq&utm_medium=listing&utm_campaign=mcp-directory
- claude learn — https://zop.dev/learn/how-to/set-up-zopnight-mcp-for-claude
- repo — https://github.com/zopdev/mcp (Apache-2.0)

---

Thanks for indexing this one - it was picked up by your auto-scan on 26 June, and the details have moved on since.

- **Name** is now **ZopDev MCP**; one server covers both ZopDev products (ZopNight for cost and FinOps, ZopDay for build and deploy).
- **Clouds**: AWS, Azure and GCP, plus Databricks on all three and Snowflake with usage-based cost.
- **Tools**: 263 (155 read, 108 write). Read-only by default, with writes opt-in per organisation and scoped per token.
- Public repo, if useful for the index: https://github.com/zopdev/mcp (Apache-2.0). Endpoint is `https://api.zop.dev/mcp-server`, streamable HTTP, OAuth 2.1 or a PAT.

Heading and one paragraph changed; every existing claim (400+ audit findings, 200+ resource types) is unchanged.
